### PR TITLE
Implement AuthContext and API usage

### DIFF
--- a/app/calendario/page.tsx
+++ b/app/calendario/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import axios from "axios";
+import { api } from "@/services/api";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameMonth, isSameDay, addMonths, subMonths, parseISO, isToday,} from "date-fns";
 import { es } from "date-fns/locale";
 import { Button } from "@/components/ui/button";
@@ -76,8 +76,8 @@ export default function CalendarioPage() {
   // --- Fetch tareas ---
   useEffect(() => {
     if (!token) return;
-    axios
-      .get("http://localhost:8000/api/tareas", {
+    api
+      .get("/tareas", {
         headers: { Authorization: `Bearer ${token}` },
         withCredentials: true,
       })
@@ -88,8 +88,8 @@ export default function CalendarioPage() {
   // --- Fetch citas ---
   useEffect(() => {
     if (!token) return;
-    axios
-      .get("http://localhost:8000/api/citas", {
+    api
+      .get("/citas", {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => {
@@ -157,8 +157,8 @@ export default function CalendarioPage() {
     const payload = preparePayload();
     try {
       if (selectedTarea) {
-        const res = await axios.put(
-          `http://localhost:8000/api/tareas/${selectedTarea.id}`,
+        const res = await api.put(
+          `/tareas/${selectedTarea.id}`,
           payload,
           {
             headers: {
@@ -174,8 +174,8 @@ export default function CalendarioPage() {
           )
         );
       } else {
-        const res = await axios.post(
-          "http://localhost:8000/api/tareas",
+        const res = await api.post(
+          "/tareas",
           payload,
           {
             headers: {
@@ -196,7 +196,7 @@ export default function CalendarioPage() {
   const deleteTarea = async (id: string) => {
     if (!token) return;
     try {
-      await axios.delete(`http://localhost:8000/api/tareas/${id}`, {
+      await api.delete(`/tareas/${id}`, {
         headers: { Authorization: `Bearer ${token}` },
         withCredentials: true,
       });
@@ -211,8 +211,8 @@ export default function CalendarioPage() {
     const t = tareas.find((x) => x.id === id);
     if (!t || !token) return;
     try {
-      const res = await axios.put(
-        `http://localhost:8000/api/tareas/${id}`,
+      const res = await api.put(
+        `/tareas/${id}`,
         { completada: !t.completada },
         {
           headers: {
@@ -233,7 +233,7 @@ export default function CalendarioPage() {
   const deleteCita = async (id: string) => {
     if (!token) return;
     try {
-      await axios.delete(`http://localhost:8000/api/citas/${id}`, {
+      await api.delete(`/citas/${id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setCitas((prev) => prev.filter((x) => x.id !== id));

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import MainLayout from "@/components/layout/main-layout"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Suspense } from "react"
+import { AuthProvider } from "@/contexts/AuthContext"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -23,7 +24,9 @@ export default function RootLayout({
       <body className={inter.className}>
         <Suspense fallback={<div>Cargando...</div>}>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-            <MainLayout>{children}</MainLayout>
+            <AuthProvider>
+              <MainLayout>{children}</MainLayout>
+            </AuthProvider>
           </ThemeProvider>
         </Suspense>
       </body>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import type React from "react"
-import axios from "axios"
+import { api } from "@/services/api"
+import { useAuth } from "@/contexts/AuthContext"
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Eye, EyeOff, LogIn } from "lucide-react"
@@ -12,6 +13,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 
 export default function LoginPage() {
   const router = useRouter()
+  const { setToken } = useAuth()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
@@ -26,7 +28,7 @@ export default function LoginPage() {
 
     try {
       // Petición real a tu API
-      const response = await axios.post("http://localhost:8000/api/login", {
+      const response = await api.post("/login", {
         email,
         password,
       })
@@ -37,9 +39,9 @@ export default function LoginPage() {
       // Extrae token, user y permissions de la respuesta
       const { id, token, user, permissions } = response.data
 
-      // Almacena el token, el usuario y los permisos en localStorage
+      // Almacena el token y demás datos en localStorage mediante el contexto
+      setToken(token)
       localStorage.setItem("userId", id)
-      localStorage.setItem("token", token)
       localStorage.setItem("user", JSON.stringify(user))
       localStorage.setItem("permissions", JSON.stringify(permissions))
 

--- a/app/seguimiento/page.tsx
+++ b/app/seguimiento/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import axios from "axios";
+import { api } from "@/services/api";
+import { useAuth } from "@/contexts/AuthContext";
 import Swal from "sweetalert2";
 import { Button } from "@/components/ui/button";
 import {
@@ -66,8 +67,8 @@ export default function SeguimientoPage() {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [pageSize, setPageSize] = useState<number>(5);
 
-  // Estados para token y user_id
-  const [token, setToken] = useState<string | null>(null);
+  // Token desde contexto y estado para user_id
+  const { token } = useAuth();
   const [userId, setUserId] = useState<string | null>(null);
 
   // Agrega estos estados nuevos cerca de los demás useState existentes:
@@ -96,14 +97,10 @@ export default function SeguimientoPage() {
     return matchesNombre && matchesEmail && matchesTelefono && matchesEstado;
   });
 
-  // Obtener token y user_id del localStorage solo en el cliente
+  // Obtener user_id del localStorage solo en el cliente
   useEffect(() => {
     if (typeof window !== "undefined") {
-      const _token = localStorage.getItem("token");
       const _userId = localStorage.getItem("user_id");
-      console.log("Token recuperado:", _token);
-      console.log("User ID recuperado:", _userId);
-      setToken(_token);
       setUserId(_userId);
     }
   }, []);
@@ -135,17 +132,10 @@ export default function SeguimientoPage() {
       setLoading(true);
       setError("");
       try {
-        const url = "http://localhost:8000/api/prospectos";
-        const res = await fetch(url, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
+        const res = await api.get("/prospectos", {
+          headers: { Authorization: `Bearer ${token}` },
         });
-        if (!res.ok) {
-          throw new Error(`Error al obtener prospectos: status ${res.status}`);
-        }
-        const json = await res.json();
+        const json = res.data;
         console.log("Respuesta completa de prospectos:", json);
         const prospectosTransformados: Prospecto[] = json.data.map((item: any) => ({
           id: String(item.id),
@@ -172,7 +162,7 @@ export default function SeguimientoPage() {
 
     const fetchInteracciones = async () => {
       try {
-        const response = await axios.get(`http://localhost:8000/api/interacciones?id_lead=${selectedProspecto.id}`, {
+        const response = await api.get(`/interacciones?id_lead=${selectedProspecto.id}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         console.log("Interacciones recibidas:", response.data);
@@ -194,7 +184,7 @@ export default function SeguimientoPage() {
     if (!token) return;
     const fetchInteracciones = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/interacciones", {
+        const response = await api.get("/interacciones", {
           headers: { Authorization: `Bearer ${token}` },
         });
         console.log("Interacciones globales recibidas:", response.data);
@@ -216,7 +206,7 @@ export default function SeguimientoPage() {
     if (!token) return;
     const fetchCitas = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/citas", {
+        const response = await api.get("/citas", {
           headers: { Authorization: `Bearer ${token}` },
         });
         console.log("Citas recibidas:", response.data);
@@ -236,7 +226,7 @@ export default function SeguimientoPage() {
     if (!token) return;
     const fetchActividades = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/actividades", {
+        const response = await api.get("/actividades", {
           headers: { Authorization: `Bearer ${token}` },
         });
         console.log("Actividades recibidas:", response.data);
@@ -259,7 +249,7 @@ export default function SeguimientoPage() {
       });
       return;
     }
-    const currentToken = localStorage.getItem("token");
+    const currentToken = token;
     if (!currentToken) {
       Swal.fire({
         icon: "error",
@@ -281,8 +271,8 @@ export default function SeguimientoPage() {
     console.log("Enviando interacción:", JSON.stringify(newInteraction, null, 2));
 
     try {
-      const response = await axios.post(
-        "http://localhost:8000/api/interacciones",
+      const response = await api.post(
+        "/interacciones",
         newInteraction,
         { headers: { Authorization: `Bearer ${currentToken}` } }
       );
@@ -319,7 +309,7 @@ export default function SeguimientoPage() {
       });
       return;
     }
-    const currentToken = localStorage.getItem("token");
+    const currentToken = token;
     if (!currentToken) {
       Swal.fire({
         icon: "error",
@@ -337,8 +327,8 @@ export default function SeguimientoPage() {
     console.log("Enviando cita:", JSON.stringify(newCita, null, 2));
 
     try {
-      const response = await axios.post(
-        "http://localhost:8000/api/citas",
+      const response = await api.post(
+        "/citas",
         newCita,
         { headers: { Authorization: `Bearer ${currentToken}` } }
       );

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useState, useEffect, useContext } from "react";
+
+interface AuthContextType {
+  token: string | null;
+  setToken: (token: string | null) => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  token: null,
+  setToken: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setTokenState] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("token");
+      setTokenState(stored);
+    }
+  }, []);
+
+  const setToken = (newToken: string | null) => {
+    if (typeof window !== "undefined") {
+      if (newToken) {
+        localStorage.setItem("token", newToken);
+      } else {
+        localStorage.removeItem("token");
+      }
+    }
+    setTokenState(newToken);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/services/api.ts
+++ b/services/api.ts
@@ -11,7 +11,7 @@ export const api = axios.create({
 // Add request interceptor for auth token
 api.interceptors.request.use(config => {
   if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('auth_token');
+    const token = localStorage.getItem('token');
     if (token && config.headers) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -25,7 +25,7 @@ api.interceptors.response.use(
   error => {
     if (error.response?.status === 401) {
       if (typeof window !== 'undefined') {
-        localStorage.removeItem('auth_token');
+        localStorage.removeItem('token');
         window.location.href = '/login';
       }
     }


### PR DESCRIPTION
## Summary
- add `AuthContext` for token handling
- wrap layout with `AuthProvider`
- update login to use context and shared API instance
- refactor seguimiento and calendario pages to use the common `api`
- align axios service with new token key

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e1581eb483288d2a08debd1622e2