### PR TITLE
Remove manual Authorization headers

### DIFF
--- a/app/calendario/page.tsx
+++ b/app/calendario/page.tsx
@@ -78,7 +78,6 @@ export default function CalendarioPage() {
     if (!token) return;
     api
       .get("/tareas", {
-        headers: { Authorization: `Bearer ${token}` },
         withCredentials: true,
       })
       .then((res) => setTareas(res.data.data))
@@ -89,9 +88,7 @@ export default function CalendarioPage() {
   useEffect(() => {
     if (!token) return;
     api
-      .get("/citas", {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      .get("/citas")
       .then((res) => {
         const arr = Array.isArray(res.data) ? res.data : res.data.data || [];
         setCitas(arr);
@@ -163,7 +160,6 @@ export default function CalendarioPage() {
           {
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
             },
             withCredentials: true,
           }
@@ -180,7 +176,6 @@ export default function CalendarioPage() {
           {
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
             },
             withCredentials: true,
           }
@@ -197,7 +192,6 @@ export default function CalendarioPage() {
     if (!token) return;
     try {
       await api.delete(`/tareas/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
         withCredentials: true,
       });
       setTareas((prev) => prev.filter((t) => t.id !== id));
@@ -217,7 +211,6 @@ export default function CalendarioPage() {
         {
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
           },
           withCredentials: true,
         }
@@ -233,9 +226,7 @@ export default function CalendarioPage() {
   const deleteCita = async (id: string) => {
     if (!token) return;
     try {
-      await api.delete(`/citas/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.delete(`/citas/${id}`);
       setCitas((prev) => prev.filter((x) => x.id !== id));
       setCitaModalOpen(false);
     } catch (err) {

--- a/app/seguimiento/page.tsx
+++ b/app/seguimiento/page.tsx
@@ -132,9 +132,7 @@ export default function SeguimientoPage() {
       setLoading(true);
       setError("");
       try {
-        const res = await api.get("/prospectos", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const res = await api.get("/prospectos");
         const json = res.data;
         console.log("Respuesta completa de prospectos:", json);
         const prospectosTransformados: Prospecto[] = json.data.map((item: any) => ({
@@ -162,9 +160,7 @@ export default function SeguimientoPage() {
 
     const fetchInteracciones = async () => {
       try {
-        const response = await api.get(`/interacciones?id_lead=${selectedProspecto.id}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const response = await api.get(`/interacciones?id_lead=${selectedProspecto.id}`);
         console.log("Interacciones recibidas:", response.data);
         if (Array.isArray(response.data.data)) {
           setInteracciones(response.data.data);
@@ -184,9 +180,7 @@ export default function SeguimientoPage() {
     if (!token) return;
     const fetchInteracciones = async () => {
       try {
-        const response = await api.get("/interacciones", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const response = await api.get("/interacciones");
         console.log("Interacciones globales recibidas:", response.data);
         if (Array.isArray(response.data)) {
           setInteracciones(response.data);
@@ -206,9 +200,7 @@ export default function SeguimientoPage() {
     if (!token) return;
     const fetchCitas = async () => {
       try {
-        const response = await api.get("/citas", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const response = await api.get("/citas");
         console.log("Citas recibidas:", response.data);
         const citasArray = Array.isArray(response.data)
           ? response.data
@@ -226,9 +218,7 @@ export default function SeguimientoPage() {
     if (!token) return;
     const fetchActividades = async () => {
       try {
-        const response = await api.get("/actividades", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const response = await api.get("/actividades");
         console.log("Actividades recibidas:", response.data);
         setActividades(response.data);
       } catch (err: any) {
@@ -273,8 +263,7 @@ export default function SeguimientoPage() {
     try {
       const response = await api.post(
         "/interacciones",
-        newInteraction,
-        { headers: { Authorization: `Bearer ${currentToken}` } }
+        newInteraction
       );
       console.log("✅ Interacción guardada:", response.data);
       setInteracciones((prev) => Array.isArray(prev) ? [...prev, response.data] : [response.data]);
@@ -329,8 +318,7 @@ export default function SeguimientoPage() {
     try {
       const response = await api.post(
         "/citas",
-        newCita,
-        { headers: { Authorization: `Bearer ${currentToken}` } }
+        newCita
       );
       console.log("✅ Cita guardada:", response.data);
       setCitas((prev) => Array.isArray(prev) ? [...prev, response.data] : [response.data]);


### PR DESCRIPTION
## Summary
- streamline axios usage by removing redundant Authorization headers in `app/seguimiento` and `app/calendario`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5482ae08328bf3450a5dd91d6eb