### PR TITLE
Centralize API URL configuration

### DIFF
--- a/app/correos/page.tsx
+++ b/app/correos/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
 import { Search, Mail } from "lucide-react"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import {
   Dialog,
@@ -97,7 +98,7 @@ export default function GestionProspectosEmail() {
       setError("")
       try {
         const token = localStorage.getItem("token")
-        const url = "http://127.0.0.1:8000/api/prospectos"
+        const url = `${API_BASE_URL}/api/prospectos`
         const res = await fetch(url, {
           headers: {
             "Authorization": `Bearer ${token}`,
@@ -234,7 +235,7 @@ export default function GestionProspectosEmail() {
         mensaje: emailData.mensaje,
       }
 
-      const response = await fetch("http://127.0.0.1:8000/api/enviar-correo", {
+      const response = await fetch(`${API_BASE_URL}/api/enviar-correo`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/app/documentos/page.tsx
+++ b/app/documentos/page.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import {
   Dialog,
   DialogContent,
@@ -73,7 +74,7 @@ export default function DocumentosPage() {
     async function loadDocs() {
       setLoading(true)
       try {
-        const res = await fetch("http://127.0.0.1:8000/api/documentos", {
+        const res = await fetch(`${API_BASE_URL}/api/documentos`, {
           headers: token
             ? { Authorization: `Bearer ${token}` }
             : undefined,
@@ -101,7 +102,7 @@ export default function DocumentosPage() {
     if (!confirm("¿Eliminar este documento?")) return
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/api/documentos/${id}`,
+        `${API_BASE_URL}/api/documentos/${id}`,
         { method: "DELETE", headers: token ? { Authorization: `Bearer ${token}` } : {} }
       )
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -115,7 +116,7 @@ export default function DocumentosPage() {
   const updateEstado = async (id: number, newEstado: EstadoDoc) => {
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/api/documentos/${id}`,
+        `${API_BASE_URL}/api/documentos/${id}`,
         {
           method: "PUT",
           headers: {
@@ -316,7 +317,7 @@ export default function DocumentosPage() {
                                   <div className="rounded-lg border overflow-hidden">
                                     {d.tipo_documento === "image" ? (
                                       <Image
-                                        src={`http://127.0.0.1:8000/${d.ruta_archivo}`}
+                                        src={`${API_BASE_URL}/${d.ruta_archivo}`}
                                         width={800}
                                         height={600}
                                         alt={d.tipo_documento}
@@ -324,7 +325,7 @@ export default function DocumentosPage() {
                                       />
                                     ) : (
                                       <iframe
-                                        src={`http://127.0.0.1:8000/storage/${d.ruta_archivo}`}
+                                        src={`${API_BASE_URL}/storage/${d.ruta_archivo}`}
                                         className="w-full h-[600px]"
                                       />
                                     )}

--- a/app/firma/page.tsx
+++ b/app/firma/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { Input } from "@/components/ui/input"
 import {
   Search,
@@ -63,7 +64,7 @@ export default function FirmaPage() {
 
   useEffect(() => {
     const token = localStorage.getItem("token") || ""
-    fetch("http://127.0.0.1:8000/api/contactos-enviados", {
+    fetch(`${API_BASE_URL}/api/contactos-enviados`, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
@@ -84,7 +85,7 @@ export default function FirmaPage() {
     const token = localStorage.getItem("token") || ""
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/api/contactos-enviados/${id}`,
+        `${API_BASE_URL}/api/contactos-enviados/${id}`,
         {
           method: "DELETE",
           headers: {
@@ -246,7 +247,7 @@ function ProspectosPendientes() {
         const respuestas = await Promise.all(
           estados.map(estado =>
             fetch(
-              `http://localhost:8000/api/prospectos/status/${encodeURIComponent(
+              `${API_BASE_URL}/api/prospectos/status/${encodeURIComponent(
                 estado
               )}`,
               { headers: { Authorization: `Bearer ${token}` } }
@@ -271,7 +272,7 @@ function ProspectosPendientes() {
 
     async function loadDocumentos() {
       try {
-        const res = await fetch("http://localhost:8000/api/documentos", {
+        const res = await fetch(`${API_BASE_URL}/api/documentos`, {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         })
         if (!res.ok) throw new Error(`HTTP ${res.status}`)

--- a/app/importar-leads/page.tsx
+++ b/app/importar-leads/page.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { ArrowLeft } from "lucide-react"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { useToast } from "@/components/ui/use-toast"
 import { useRouter } from "next/navigation"
 import Swal from "sweetalert2"
@@ -45,7 +46,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
 
   // Función para recargar las columnas desde el backend.
   const fetchColumns = () => {
-    fetch("http://localhost:8000/api/columns")
+    fetch(`${API_BASE_URL}/api/columns`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
         return res.json()
@@ -114,7 +115,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
     }
 
     if (editingColumn.id === 0) {
-      fetch("http://localhost:8000/api/columns", {
+      fetch(`${API_BASE_URL}/api/columns`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -149,7 +150,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
           })
         })
     } else {
-      fetch(`http://localhost:8000/api/columns/${editingColumn.id}`, {
+      fetch(`${API_BASE_URL}/api/columns/${editingColumn.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -215,7 +216,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
       hasFile: formData.has("file"),
     });
 
-    fetch("http://localhost:8000/api/import", {
+    fetch(`${API_BASE_URL}/api/import`, {
       method: "POST",
       body: formData,
       headers: { Authorization: `Bearer ${token}` },

--- a/app/inscripcion/admin/periodos/page.tsx
+++ b/app/inscripcion/admin/periodos/page.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { API_BASE_URL } from "@/utils/apiConfig";
 import {
   Table,
   TableBody,
@@ -71,8 +72,7 @@ function generateCodigo(nombre: string): string {
   return `${initials}-${year}`;
 }
 
-axios.defaults.baseURL =
-  process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000/api";
+axios.defaults.baseURL = API_BASE_URL + "/api";
 
 type PeriodoAPI = {
   id: number;

--- a/app/leads-asignados/page.tsx
+++ b/app/leads-asignados/page.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Checkbox } from "@/components/ui/checkbox"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import {
   Table,
   TableBody,
@@ -57,7 +58,7 @@ export default function GestionProspectos() {
       setError("")
       try {
         const token = localStorage.getItem("token")
-        const url = "http://127.0.0.1:8000/api/prospectos"
+        const url = `${API_BASE_URL}/api/prospectos`
         const res = await fetch(url, {
           headers: {
             "Authorization": `Bearer ${token}`,

--- a/app/seguridad/sesiones/page.tsx
+++ b/app/seguridad/sesiones/page.tsx
@@ -21,8 +21,10 @@ interface Session {
   activa: boolean;
 }
 
+import { API_BASE_URL } from "@/utils/apiConfig";
+
 // URL base de tu servidor Laravel (CORREGIDO)
-const LARAVEL_API_URL = "http://localhost:8000";
+const LARAVEL_API_URL = API_BASE_URL;
 
 export default function SesionesActivas() {
   // Tipamos el estado para que sea un arreglo de Session

--- a/app/seguridad/usuarios/page.tsx
+++ b/app/seguridad/usuarios/page.tsx
@@ -16,6 +16,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 // Esquema para crear/editar usuario basado en el controlador de Laravel
 const usuarioSchema = z.object({
@@ -105,7 +106,7 @@ export default function GestionUsuarios() {
   useEffect(() => {
     const fetchRoles = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/roles")
+        const response = await axios.get(`${API_BASE_URL}/api/roles`)
         setRoles(response.data)
       } catch (error) {
         console.error("Error fetching roles:", error)
@@ -118,7 +119,7 @@ export default function GestionUsuarios() {
   useEffect(() => {
     const fetchUsuarios = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/users")
+        const response = await axios.get(`${API_BASE_URL}/api/users`)
         setUsuarios(response.data)
       } catch (error) {
         console.error("Error fetching users:", error)
@@ -170,7 +171,7 @@ export default function GestionUsuarios() {
   // Función para crear usuario
   const handleUserSubmit = async (data: Usuario) => {
     try {
-      const response = await axios.post("http://localhost:8000/api/users", data)
+      const response = await axios.post(`${API_BASE_URL}/api/users`, data)
       setUsuarios((prev) => [...prev, response.data])
       setIsUserDialogOpen(false)
       userForm.reset()
@@ -220,7 +221,7 @@ export default function GestionUsuarios() {
   const handleEditSubmit = async (data: Usuario) => {
     if (!selectedUser) return
     try {
-      const response = await axios.put(`http://localhost:8000/api/users/${selectedUser.id}`, data)
+      const response = await axios.put(`${API_BASE_URL}/api/users/${selectedUser.id}`, data)
       setUsuarios((prev) =>
         prev.map((u) => (u.id === selectedUser.id ? response.data : u))
       )
@@ -265,7 +266,7 @@ export default function GestionUsuarios() {
       if (result.isConfirmed) {
         try {
           const updatedData = { is_active: false }
-          const response = await axios.put(`http://localhost:8000/api/users/${usuario.id}`, updatedData)
+          const response = await axios.put(`${API_BASE_URL}/api/users/${usuario.id}`, updatedData)
           setUsuarios((prev) =>
             prev.map((u) => (u.id === usuario.id ? response.data : u))
           )
@@ -305,7 +306,7 @@ export default function GestionUsuarios() {
       })
       if (result.isConfirmed) {
         try {
-          const response = await axios.put(`http://localhost:8000/api/users/${usuario.id}`, { is_active: true })
+          const response = await axios.put(`${API_BASE_URL}/api/users/${usuario.id}`, { is_active: true })
           setUsuarios((prev) =>
             prev.map((u) => (u.id === usuario.id ? response.data : u))
           )
@@ -365,7 +366,7 @@ export default function GestionUsuarios() {
       try {
         await Promise.all(
           selectedUserIds.map((userId: number) =>
-            axios.put(`http://localhost:8000/api/users/${userId}`, {
+            axios.put(`${API_BASE_URL}/api/users/${userId}`, {
               is_active: action === "inactivate" ? false : true
             })
           )
@@ -877,7 +878,7 @@ const handleToggleActiveUser = async (usuario: any) => {
     if (result.isConfirmed) {
       try {
         const updatedData = { is_active: false }
-        const response = await axios.put(`http://localhost:8000/api/users/${usuario.id}`, updatedData)
+        const response = await axios.put(`${API_BASE_URL}/api/users/${usuario.id}`, updatedData)
         window.location.reload()
       } catch (error: any) {
         console.error("Error inactivating user:", error)
@@ -910,7 +911,7 @@ const handleToggleActiveUser = async (usuario: any) => {
     })
     if (result.isConfirmed) {
       try {
-        const response = await axios.put(`http://localhost:8000/api/users/${usuario.id}`, { is_active: true })
+        const response = await axios.put(`${API_BASE_URL}/api/users/${usuario.id}`, { is_active: true })
         window.location.reload()
       } catch (error: any) {
         console.error("Error reactivating user:", error)
@@ -946,7 +947,7 @@ const handleReactivateUser = async (usuario: any) => {
   })
   if (result.isConfirmed) {
     try {
-      const response = await axios.put(`http://localhost:8000/api/users/${usuario.id}`, { is_active: true })
+      const response = await axios.put(`${API_BASE_URL}/api/users/${usuario.id}`, { is_active: true })
       window.location.reload()
     } catch (error: any) {
       console.error("Error reactivating user:", error)

--- a/components/admin/Modals/EditProspectModal.tsx
+++ b/components/admin/Modals/EditProspectModal.tsx
@@ -8,6 +8,7 @@ import {
     DialogFooter,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import {
     Select,
     SelectTrigger,
@@ -73,7 +74,7 @@ export default function EditProspectModal({
             if (bulkIds && bulkIds.length > 0) {
                 // Actualización masiva usando el endpoint bulk-assign
                 const res = await fetch(
-                    "http://127.0.0.1:8000/api/prospectos/bulk-assign",
+                    `${API_BASE_URL}/api/prospectos/bulk-assign`,
                     {
                         method: "PUT",
                         headers: {
@@ -95,7 +96,7 @@ export default function EditProspectModal({
             } else if (prospect) {
                 // Actualización individual
                 const res = await fetch(
-                    `http://127.0.0.1:8000/api/prospectos/${prospect.id}/assign`,
+                    `${API_BASE_URL}/api/prospectos/${prospect.id}/assign`,
                     {
                         method: "PUT",
                         headers: {

--- a/components/admin/advisors.tsx
+++ b/components/admin/advisors.tsx
@@ -16,9 +16,10 @@ import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 // Endpoints
-const API_BASE = "http://127.0.0.1:8000/api"
+const API_BASE = `${API_BASE_URL}/api`
 const API_USERS_ROLE = `${API_BASE}/users/role/7`
 const API_USERS = `${API_BASE}/users`
 const API_COMM = `${API_BASE}/commissions`

--- a/components/admin/duplicates.tsx
+++ b/components/admin/duplicates.tsx
@@ -15,6 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import {
   Select,
   SelectTrigger,
@@ -23,7 +24,7 @@ import {
   SelectItem,
 } from "@/components/ui/select"
 
-const API_URL = "http://127.0.0.1:8000/api"
+const API_URL = `${API_BASE_URL}/api`
 
 interface Prospect {
   id: number

--- a/components/admin/lead-management.tsx
+++ b/components/admin/lead-management.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, } from "@/components/ui/dropdown-menu"
 import swal from "sweetalert2"
 import { cn } from "@/lib/utils"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 
 import EditProspectModal from "./Modals/EditProspectModal"
@@ -62,7 +63,7 @@ export default function GestionProspectos() {
   useEffect(() => {
     setLoading(true)
     const qs = estadoFilter !== "todos" ? `?status=${estadoFilter}` : ""
-    fetch(`http://127.0.0.1:8000/api/prospectos${qs}`, {
+    fetch(`${API_BASE_URL}/api/prospectos${qs}`, {
       headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
     })
       .then(r => r.json())
@@ -96,7 +97,7 @@ export default function GestionProspectos() {
 
   // carga de asesores
   useEffect(() => {
-    fetch("http://127.0.0.1:8000/api/users/role/7", {
+    fetch(`${API_BASE_URL}/api/users/role/7`, {
       headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
     })
       .then(r => r.json())
@@ -118,7 +119,7 @@ export default function GestionProspectos() {
   const handleReasignar = async (id: string, asesorId: number) => {
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/api/prospectos/${id}/assign`,
+        `${API_BASE_URL}/api/prospectos/${id}/assign`,
         {
           method: "PUT",
           headers: {
@@ -295,7 +296,7 @@ export default function GestionProspectos() {
                 // Realiza las peticiones DELETE de forma paralela; si la API no tiene endpoint masivo, se envían individualmente.
                 await Promise.all(
                   selectedIds.map(id =>
-                    fetch(`http://127.0.0.1:8000/api/prospectos/${id}`, {
+                    fetch(`${API_BASE_URL}/api/prospectos/${id}`, {
                       method: "DELETE",
                       headers: {
                         Authorization: `Bearer ${localStorage.getItem("token")}`,
@@ -521,7 +522,7 @@ export default function GestionProspectos() {
 
           try {
             const res = await fetch(
-              `http://127.0.0.1:8000/api/prospectos/${activeProspect.id}`,
+              `${API_BASE_URL}/api/prospectos/${activeProspect.id}`,
               {
                 method: "DELETE",
                 headers: {

--- a/components/captura/captura-prospectos.tsx
+++ b/components/captura/captura-prospectos.tsx
@@ -8,6 +8,7 @@ import * as z from "zod"
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Form, FormControl, FormField, FormItem, FormLabel, FormMessage,
@@ -106,7 +107,7 @@ export default function CapturaProspectos() {
   useEffect(() => {
     const fetchProgramas = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/programas")
+        const response = await axios.get(`${API_BASE_URL}/api/programas`)
         setProgramas(response.data)
       } catch (error) {
         console.error("❌ Error al obtener programas:", error)
@@ -119,7 +120,7 @@ export default function CapturaProspectos() {
   useEffect(() => {
     const fetchEmpresas = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/convenios")
+        const response = await axios.get(`${API_BASE_URL}/api/convenios`)
         setEmpresas(response.data)
       } catch (error) {
         console.error("❌ Error al obtener empresas:", error)
@@ -133,7 +134,7 @@ export default function CapturaProspectos() {
   useEffect(() => {
     const fetchUbicacionGuatemala = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/ubicacion/1")
+        const response = await axios.get(`${API_BASE_URL}/api/ubicacion/1`)
         setDepartamentos(response.data.departamentos)
       } catch (error) {
         console.error("❌ Error al obtener ubicación de Guatemala:", error)
@@ -171,7 +172,7 @@ export default function CapturaProspectos() {
         fecha: fechaFormateada,
         medio_conocimiento_institucion: data.Origen,
       }
-      await axios.post("http://localhost:8000/api/prospectos", payload, {
+      await axios.post(`${API_BASE_URL}/api/prospectos`, payload, {
         headers: { Authorization: `Bearer ${token}` },
       })
       Swal.fire({

--- a/components/captura/tabs/CargaMasivaProspectos.tsx
+++ b/components/captura/tabs/CargaMasivaProspectos.tsx
@@ -21,6 +21,7 @@ import { ArrowLeft } from "lucide-react"
 import { useToast } from "@/components/ui/use-toast"
 import { useRouter } from "next/navigation"
 import Swal from "sweetalert2"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 interface Column {
   id: number
@@ -45,7 +46,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
 
   // Función para recargar las columnas desde el backend.
   const fetchColumns = () => {
-    fetch("http://localhost:8000/api/columns")
+    fetch(`${API_BASE_URL}/api/columns`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
         return res.json()
@@ -114,7 +115,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
     }
 
     if (editingColumn.id === 0) {
-      fetch("http://localhost:8000/api/columns", {
+      fetch(`${API_BASE_URL}/api/columns`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -149,7 +150,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
           })
         })
     } else {
-      fetch(`http://localhost:8000/api/columns/${editingColumn.id}`, {
+      fetch(`${API_BASE_URL}/api/columns/${editingColumn.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -215,7 +216,7 @@ export default function CargaMasivaProspectos({ onImportSuccess }: CargaMasivaPr
       hasFile: formData.has("file"),
     });
 
-    fetch("http://localhost:8000/api/import", {
+    fetch(`${API_BASE_URL}/api/import`, {
       method: "POST",
       body: formData,
       headers: { Authorization: `Bearer ${token}` },

--- a/components/firma/student-details.tsx
+++ b/components/firma/student-details.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { CheckCircle, ZoomIn, ZoomOut, RotateCw, Loader2 } from "lucide-react"
 import Swal from 'sweetalert2'
+import { API_BASE_URL } from '@/utils/apiConfig'
 
 interface Student {
   id: string
@@ -72,7 +73,7 @@ export function StudentDetails() {
         try {
           const token = localStorage.getItem("token")
           const res = await fetch(
-            `http://127.0.0.1:8000/api/prospectos/${studentId}`,
+            `${API_BASE_URL}/api/prospectos/${studentId}`,
             { headers: { Authorization: `Bearer ${token}` } }
           )
           const json = await res.json()
@@ -94,7 +95,7 @@ export function StudentDetails() {
         try {
           const token = localStorage.getItem("token")
           const res = await fetch(
-            `http://127.0.0.1:8000/api/estudiante-programa?prospecto_id=${studentId}`,
+            `${API_BASE_URL}/api/estudiante-programa?prospecto_id=${studentId}`,
             { headers: { Authorization: `Bearer ${token}` } }
           )
           if (!res.ok) throw new Error("Error al cargar programas")
@@ -112,7 +113,7 @@ export function StudentDetails() {
     ; (async () => {
       try {
         const token = localStorage.getItem("token")
-        const res = await fetch(`http://127.0.0.1:8000/api/user`, {
+        const res = await fetch(`${API_BASE_URL}/api/user`, {
           headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
         })
         const user: User = await res.json()
@@ -201,7 +202,7 @@ export function StudentDetails() {
     try {
       const token = localStorage.getItem("token")
       const res = await fetch(
-        `http://127.0.0.1:8000/api/prospectos/${studentId}/enviar-contrato`,
+        `${API_BASE_URL}/api/prospectos/${studentId}/enviar-contrato`,
         {
           method: "POST",
           headers: {

--- a/components/gestion/cambiar-estado.tsx
+++ b/components/gestion/cambiar-estado.tsx
@@ -5,6 +5,7 @@ import Swal from "sweetalert2"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 interface Prospecto {
   id: string
@@ -17,7 +18,7 @@ interface CambiarEstadoProps {
   onClose: () => void
 }
 
-const API_URL = "http://127.0.0.1:8000/api"
+const API_URL = `${API_BASE_URL}/api`
 
 export default function CambiarEstado({ prospecto, onClose }: CambiarEstadoProps) {
   const [selectedEstado, setSelectedEstado] = useState(prospecto.estado)

--- a/components/gestion/editar-prospecto.tsx
+++ b/components/gestion/editar-prospecto.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import Swal from "sweetalert2"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 interface Prospecto {
   id: string
@@ -24,7 +25,7 @@ interface EditarProspectoProps {
   onClose: () => void
 }
 
-const API_URL = "http://127.0.0.1:8000/api"
+const API_URL = `${API_BASE_URL}/api`
 
 export default function EditarProspecto({ prospecto, onClose }: EditarProspectoProps) {
   // inicializa los estados con las props

--- a/components/gestion/gestion-prospectos.tsx
+++ b/components/gestion/gestion-prospectos.tsx
@@ -22,8 +22,9 @@ import { Checkbox } from "@/components/ui/checkbox"
 import DetallesProspecto from "./detalles-prospecto"
 import EditarProspecto from "./editar-prospecto"
 import CambiarEstado from "./cambiar-estado"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
-const API_URL = "http://127.0.0.1:8000/api"
+const API_URL = `${API_BASE_URL}/api`
 
 interface Prospecto {
   id: string

--- a/components/inscripcion/gestion-fichas.tsx
+++ b/components/inscripcion/gestion-fichas.tsx
@@ -34,8 +34,9 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { FichaEstudiante } from "@/components/inscripcion/types"
 import FichaDetalleModal from "@/components/inscripcion/modal/FichaDetalleModal"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+const API_URL = process.env.NEXT_PUBLIC_API_URL || API_BASE_URL
 const CONTEO_REVISADAS_KEY = "fichasRevisadasCount"
 
 function incrementarRevisadas() {

--- a/components/inscripcion/tabs/ProspectSearchModal.tsx
+++ b/components/inscripcion/tabs/ProspectSearchModal.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 import { Prospecto } from "../types"
 
@@ -59,7 +60,7 @@ export default function ProspectSearchModal({
 
       try {
         const token = localStorage.getItem("token")
-        const url = `http://127.0.0.1:8000/api/prospectos?status=${encodeURIComponent(
+        const url = `${API_BASE_URL}/api/prospectos?status=${encodeURIComponent(
           "Preinscripción"
         )}`
         const res = await fetch(url, {

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -29,6 +29,7 @@ import {
   Database,
   AlertTriangle,
 } from "lucide-react"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
 import { cn } from "@/lib/utils"
@@ -44,7 +45,7 @@ export default function Sidebar({ open, className }: SidebarProps) {
 
   // Hacemos fetch para obtener el rol del usuario
   useEffect(() => {
-    fetch("http://127.0.0.1:8000/api/user", {
+    fetch(`${API_BASE_URL}/api/user`, {
       credentials: "include",
     })
       .then(res => res.json())

--- a/utils/apiConfig.ts
+++ b/utils/apiConfig.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8080';
+

--- a/utils/crearUsuario.ts
+++ b/utils/crearUsuario.ts
@@ -1,6 +1,7 @@
 import Swal from "sweetalert2"
+import { API_BASE_URL } from "./apiConfig"
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/"
+const API_URL = `${API_BASE_URL}/`
 
 export interface CrearUsuarioPayload {
   username: string


### PR DESCRIPTION
## Summary
- create `API_BASE_URL` constant to centralize API endpoint configuration
- refactor API calls in several pages and components to use this constant
- update axios default base URL

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5e49d2883288c986db2139e6046