### PR TITLE
Fix API URLs to use config

### DIFF
--- a/components/inscripcion/archibobas.tsx
+++ b/components/inscripcion/archibobas.tsx
@@ -16,6 +16,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Switch } from "@/components/ui/switch"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import axios from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 type FichaEstudiante = {
   id: number
@@ -40,7 +41,7 @@ useEffect(() => {
   const fetchFichas = async () => {
     try {
       const token = localStorage.getItem("token")
-      const res = await fetch("http://localhost:8000/api/fichas/pendientes", {
+      const res = await fetch(`${API_BASE_URL}/api/fichas/pendientes`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/components/inscripcion/modal/FichaDetalleModal.tsx
+++ b/components/inscripcion/modal/FichaDetalleModal.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 
 import { FichaEstudiante } from "../types"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 interface Props {
   ficha: FichaEstudiante
@@ -100,7 +101,7 @@ export default function FichaDetalleModal({
       try {
         const token = localStorage.getItem("token") ?? ""
         const resFicha = await fetch(
-          `http://localhost:8000/api/fichas/${ficha.id}`,
+          `${API_BASE_URL}/api/fichas/${ficha.id}`,
           { headers: { Authorization: `Bearer ${token}` } }
         )
         const json = await resFicha.json()
@@ -111,7 +112,7 @@ export default function FichaDetalleModal({
         setProgramasInscritos(json.programas ?? [])
         setDocumentos(json.documentos ?? [])
 
-        const resProg = await fetch("http://localhost:8000/api/programas")
+        const resProg = await fetch(`${API_BASE_URL}/api/programas`)
         setCatalogoProgramas(await resProg.json())
 
         // Leer estado 'revisada' de localStorage

--- a/components/inscripcion/registration-form.tsx
+++ b/components/inscripcion/registration-form.tsx
@@ -26,6 +26,7 @@ import ProspectSearchModal from "./tabs/ProspectSearchModal"
 import type { ProgramaConDuracion } from "./types"
 
 import axios from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 
 export default function RegistrationForm() {
   const [activeTab, setActiveTab] = useState<TabId>("personal")
@@ -74,12 +75,15 @@ export default function RegistrationForm() {
 
   const handleFinalizarInscripcion = async () => {
     try {
-      const response = await axios.post("http://localhost:8000/api/inscripciones/finalizar", {
-        personales: { ...datosPersonales, id: prospectoId },
-        laborales: datosLaborales,
-        academicos: datosAcademicos,
-        financieros: datosFinancieros,
-      });
+      const response = await axios.post(
+        `${API_BASE_URL}/api/inscripciones/finalizar`,
+        {
+          personales: { ...datosPersonales, id: prospectoId },
+          laborales: datosLaborales,
+          academicos: datosAcademicos,
+          financieros: datosFinancieros,
+        }
+      );
   
       const nuevoId = response.data.prospecto_id;
       const estudianteProgramas: any[] = response.data.programas || [];
@@ -93,14 +97,14 @@ export default function RegistrationForm() {
         formData.append("tipo_documento", doc.id);
         formData.append("file", doc.archivo!);
   
-        await axios.post("http://localhost:8000/api/documentos", formData, {
+        await axios.post(`${API_BASE_URL}/api/documentos`, formData, {
           headers: { "Content-Type": "multipart/form-data" },
         });
       }
   
       // Generar plan de pagos para cada programa
       for (const programa of estudianteProgramas) {
-        await axios.post("http://localhost:8000/api/plan-pagos/generar", {
+        await axios.post(`${API_BASE_URL}/api/plan-pagos/generar`, {
           estudiante_programa_id: programa.id,
         });
       }

--- a/components/inscripcion/tabs/AcademicoTab.tsx
+++ b/components/inscripcion/tabs/AcademicoTab.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import axios from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { DatosAcademicos } from "../types"
 
 interface Programa {
@@ -42,9 +43,10 @@ export default function AcademicoTab({ datos, setDatos, goPrev, goNext }: Props)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    axios.get<Programa[]>("http://localhost:8000/api/programas")
-      .then(resp => setProgramas(resp.data))
-      .catch(err => console.error("❌ Error al obtener programas:", err))
+    axios
+      .get<Programa[]>(`${API_BASE_URL}/api/programas`)
+      .then((resp) => setProgramas(resp.data))
+      .catch((err) => console.error("❌ Error al obtener programas:", err))
   }, [])
 
   useEffect(() => {

--- a/components/inscripcion/tabs/DocumentosTab.tsx
+++ b/components/inscripcion/tabs/DocumentosTab.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useEffect, useState, useRef, useMemo, Dispatch, SetStateAction } from "react"
 import axios, { AxiosError } from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { ArrowLeft, ArrowRight, FileText, Info, Upload, X, CheckCircle } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
@@ -73,10 +74,10 @@ export default function DocumentosTab({
     formData.append("tipo_documento", uploadTarget.current)
     formData.append("file", file)
 
-    try {
-      await axios.post("http://localhost:8000/api/documentos", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-      })
+      try {
+        await axios.post(`${API_BASE_URL}/api/documentos`, formData, {
+          headers: { "Content-Type": "multipart/form-data" },
+        })
       setDocumentos(docs =>
         docs.map(d =>
           d.id === uploadTarget.current

--- a/components/inscripcion/tabs/FinancieroTab.tsx
+++ b/components/inscripcion/tabs/FinancieroTab.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useEffect, useState, useRef, useMemo } from "react"
 import axios, { AxiosError } from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { ArrowLeft, ArrowRight, CheckCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -54,7 +55,8 @@ export default function FinancieroTab({
 
   /* ——— Cargar convenios ——— */
   useEffect(() => {
-    axios.get<Convenio[]>("http://localhost:8000/api/convenios")
+    axios
+      .get<Convenio[]>(`${API_BASE_URL}/api/convenios`)
       .then(resp => setConvenios(resp.data))
       .catch(err => {
         console.error("Error cargando convenios:", err)
@@ -88,9 +90,9 @@ export default function FinancieroTab({
       if (cache.current.has(cacheKey)) {
         return Promise.resolve({ ok: true as const, data: cache.current.get(cacheKey)! })
       }
-      const url = datos.tieneConvenio
-        ? `http://localhost:8000/api/precios/convenio/${convenioId}/${programaId}?meses=${duracion}`
-        : `http://localhost:8000/api/precios/programa/${programaId}?meses=${duracion}`
+    const url = datos.tieneConvenio
+        ? `${API_BASE_URL}/api/precios/convenio/${convenioId}/${programaId}?meses=${duracion}`
+        : `${API_BASE_URL}/api/precios/programa/${programaId}?meses=${duracion}`
       return axios
         .get<{ inscripcion: number; cuota_mensual: number }>(url)
         .then(r => {

--- a/components/inscripcion/tabs/LaboralTab.tsx
+++ b/components/inscripcion/tabs/LaboralTab.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import axios from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { DatosLaborales } from "../types"
 
 interface Props {
@@ -56,8 +57,8 @@ export default function LaboralTab({ datos, setDatos, goPrev, goNext }: Props) {
       })
 
       // Cargar departamentos desde API
-      axios
-        .get("http://localhost:8000/api/ubicacion/1")
+        axios
+          .get(`${API_BASE_URL}/api/ubicacion/1`)
         .then((resp) => {
           const deps = resp.data.departamentos.map((d: any) => ({
             id: d.id,

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import axios from "axios"
+import { API_BASE_URL } from "@/utils/apiConfig"
 import { useRouter, usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Loader } from "lucide-react"
@@ -58,7 +59,7 @@ export default function Sidebar({ open, className }: SidebarProps) {
       const token = localStorage.getItem("token")
       if (token) {
         try {
-          const response = await axios.get("http://localhost:8000/api/users", {
+          const response = await axios.get(`${API_BASE_URL}/api/users`, {
             headers: {
               Authorization: `Bearer ${token}`,
             },
@@ -84,7 +85,7 @@ export default function Sidebar({ open, className }: SidebarProps) {
       const token = localStorage.getItem("token");
       if (token) {
         await axios.post(
-          "http://localhost:8000/api/logout",
+          `${API_BASE_URL}/api/logout`,
           {},
           {
             headers: {

--- a/components/permisos/permisos-modulos-tab.tsx
+++ b/components/permisos/permisos-modulos-tab.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import axios from "axios";
+import { API_BASE_URL } from "@/utils/apiConfig";
 import Swal from "sweetalert2";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -208,7 +209,7 @@ export default function PermisosModulosTab() {
 
   const fetchModulos = async () => {
     try {
-      const response = await axios.get("http://localhost:8000/api/modules");
+      const response = await axios.get(`${API_BASE_URL}/api/modules`);
       const modulosTransformados = response.data.map((m: any) =>
         transformModule(m)
       );
@@ -256,10 +257,10 @@ export default function PermisosModulosTab() {
         icono: data.icono,
       };
       if (isEditing && currentModulo) {
-        const response = await axios.put(
-          `http://localhost:8000/api/modules/${currentModulo.id}`,
-          payload
-        );
+          const response = await axios.put(
+            `${API_BASE_URL}/api/modules/${currentModulo.id}`,
+            payload
+          );
         const moduloActualizado = transformModule(response.data);
         setModulos(
           modulos.map((m) =>
@@ -267,10 +268,10 @@ export default function PermisosModulosTab() {
           )
         );
       } else {
-        const response = await axios.post(
-          "http://localhost:8000/api/modules",
-          payload
-        );
+          const response = await axios.post(
+            `${API_BASE_URL}/api/modules`,
+            payload
+          );
         const nuevoModulo = transformModule(response.data);
         setModulos([...modulos, nuevoModulo]);
       }
@@ -285,10 +286,10 @@ export default function PermisosModulosTab() {
       const modulo = modulos.find((m) => m.id === id);
       if (!modulo) return;
       const payload = { status: !modulo.activo };
-      const response = await axios.put(
-        `http://localhost:8000/api/modules/${id}`,
-        payload
-      );
+        const response = await axios.put(
+          `${API_BASE_URL}/api/modules/${id}`,
+          payload
+        );
       const moduloActualizado = transformModule(response.data);
       setModulos(
         modulos.map((m) => (m.id === id ? moduloActualizado : m))
@@ -316,7 +317,7 @@ export default function PermisosModulosTab() {
           return;
         }
       }
-      await axios.delete(`http://localhost:8000/api/modules/${id}`);
+        await axios.delete(`${API_BASE_URL}/api/modules/${id}`);
       setModulos(modulos.filter((m) => m.id !== id));
       // Mostrar mensaje de éxito
       Swal.fire({
@@ -657,10 +658,10 @@ function ModuleViewModal({
       }
       console.log("Enviando solicitud para crear vista en el módulo:", module_id);
       // Se incluye el campo icono en el payload
-      const response = await axios.post(
-        `http://localhost:8000/api/modules/${module_id}/views`,
-        { ...payload, icono: data.icono }
-      );
+        const response = await axios.post(
+          `${API_BASE_URL}/api/modules/${module_id}/views`,
+          { ...payload, icono: data.icono }
+        );
       console.log("Respuesta del servidor:", response.data);
       const nuevaVista: Vista = response.data.data;
       onViewCreated(nuevaVista);

--- a/components/permisos/permisos-roles-tab.tsx
+++ b/components/permisos/permisos-roles-tab.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { API_BASE_URL } from "@/utils/apiConfig";
 import Swal from "sweetalert2";
 
 import { Button } from "@/components/ui/button";
@@ -101,7 +102,7 @@ export default function PermisosRolesTab() {
 
   const fetchRoles = async () => {
     try {
-      const response = await axios.get("http://localhost:8000/api/roles");
+      const response = await axios.get(`${API_BASE_URL}/api/roles`);
       // Asumimos que response.data es un array de roles
       setRoles(response.data);
     } catch (error) {
@@ -123,7 +124,7 @@ export default function PermisosRolesTab() {
       if (isEditing && selectedRol) {
         // EDITAR
         const response = await axios.put(
-          `http://localhost:8000/api/roles/${selectedRol.id}`,
+          `${API_BASE_URL}/api/roles/${selectedRol.id}`,
           data
         );
         // Actualizamos en el estado
@@ -138,7 +139,7 @@ export default function PermisosRolesTab() {
         });
       } else {
         // CREAR
-        const response = await axios.post("http://localhost:8000/api/roles", data);
+        const response = await axios.post(`${API_BASE_URL}/api/roles`, data);
         setRoles((prev) => [...prev, response.data]);
         Swal.fire({
           title: "Rol creado",
@@ -176,7 +177,7 @@ export default function PermisosRolesTab() {
     if (!result.isConfirmed) return;
 
     try {
-      await axios.delete(`http://localhost:8000/api/roles/${rol.id}`);
+      await axios.delete(`${API_BASE_URL}/api/roles/${rol.id}`);
       setRoles((prev) => prev.filter((r) => r.id !== rol.id));
       Swal.fire({
         title: "Rol eliminado",

--- a/components/permisos/permisos-usuarios-tab.tsx
+++ b/components/permisos/permisos-usuarios-tab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import axios from "axios";
+import { API_BASE_URL } from "@/utils/apiConfig";
 import Swal from "sweetalert2";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -90,7 +91,7 @@ export default function PermisosUsuariosTab() {
   // Trae la lista de usuarios desde la API
   const fetchUsuarios = async () => {
     try {
-      const response = await axios.get("http://localhost:8000/api/users");
+        const response = await axios.get(`${API_BASE_URL}/api/users`);
       const usuariosTransformados = response.data.map((u: any) => transformUser(u));
       setUsuarios(usuariosTransformados);
     } catch (error) {
@@ -146,10 +147,10 @@ export default function PermisosUsuariosTab() {
     try {
       if (isEditing && currentUser) {
         // EDITAR
-        const response = await axios.put(
-          `http://localhost:8000/api/users/${currentUser.id}`,
-          data
-        );
+          const response = await axios.put(
+            `${API_BASE_URL}/api/users/${currentUser.id}`,
+            data
+          );
         const usuarioActualizado = transformUser(response.data);
         setUsuarios((prev) =>
           prev.map((u) => (u.id === currentUser.id ? usuarioActualizado : u))
@@ -162,7 +163,7 @@ export default function PermisosUsuariosTab() {
         });
       } else {
         // CREAR
-        const response = await axios.post("http://localhost:8000/api/users", data);
+          const response = await axios.post(`${API_BASE_URL}/api/users`, data);
         const nuevoUsuario = transformUser(response.data);
         setUsuarios((prev) => [...prev, nuevoUsuario]);
         Swal.fire({
@@ -202,10 +203,10 @@ export default function PermisosUsuariosTab() {
     if (!result.isConfirmed) return;
 
     try {
-      const response = await axios.put(
-        `http://localhost:8000/api/users/${usuario.id}`,
-        { is_active: !usuario.is_active }
-      );
+        const response = await axios.put(
+          `${API_BASE_URL}/api/users/${usuario.id}`,
+          { is_active: !usuario.is_active }
+        );
       const actualizado = transformUser(response.data);
       setUsuarios((prev) => prev.map((u) => (u.id === usuario.id ? actualizado : u)));
       Swal.fire({
@@ -238,7 +239,7 @@ export default function PermisosUsuariosTab() {
     if (!result.isConfirmed) return;
 
     try {
-      await axios.delete(`http://localhost:8000/api/users/${usuario.id}`);
+      await axios.delete(`${API_BASE_URL}/api/users/${usuario.id}`);
       setUsuarios((prev) => prev.filter((u) => u.id !== usuario.id));
       Swal.fire({
         title: "Usuario eliminado",

--- a/components/permisos/permisos-vistas-tab.tsx
+++ b/components/permisos/permisos-vistas-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import axios from "axios";
+import { API_BASE_URL } from "@/utils/apiConfig";
 import Swal from "sweetalert2";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -79,7 +80,7 @@ export default function PermisosVistasTab() {
   useEffect(() => {
     const fetchUsuarios = async () => {
       try {
-        const response = await axios.get("http://localhost:8000/api/users");
+        const response = await axios.get(`${API_BASE_URL}/api/users`);
         console.log("Respuesta de usuarios:", response.data);
         // Si la respuesta viene en response.data.data, ajusta aquí
         const usuariosTransformados = response.data.map((user: any) => ({
@@ -102,12 +103,14 @@ export default function PermisosVistasTab() {
   useEffect(() => {
     const fetchModulesWithViews = async () => {
       try {
-        const modulesRes = await axios.get("http://localhost:8000/api/modules");
+          const modulesRes = await axios.get(`${API_BASE_URL}/api/modules`);
         const modulesData: Module[] = modulesRes.data;
         const modulesWithViews = await Promise.all(
           modulesData.map(async (module) => {
             try {
-              const viewsRes = await axios.get(`http://localhost:8000/api/modules/${module.id}/views`);
+                const viewsRes = await axios.get(
+                  `${API_BASE_URL}/api/modules/${module.id}/views`
+                );
               const views: ModuleView[] = viewsRes.data.data;
               return { ...module, views };
             } catch (error) {
@@ -135,7 +138,9 @@ export default function PermisosVistasTab() {
       if (!selectedUsuario) return;
       setIsLoading(true);
       try {
-        const response = await axios.get(`http://localhost:8000/api/userpermissions?user_id=${selectedUsuario}`);
+          const response = await axios.get(
+            `${API_BASE_URL}/api/userpermissions?user_id=${selectedUsuario}`
+          );
         if (response.data.success) {
           const permisosIds = response.data.data.map((perm: any) => perm.permission_id);
           setSelectedPermisos(permisosIds);
@@ -185,7 +190,10 @@ export default function PermisosVistasTab() {
         user_id: selectedUsuario,
         permissions: selectedPermisos,
       };
-      const response = await axios.post("http://localhost:8000/api/userpermissions", payload);
+      const response = await axios.post(
+        `${API_BASE_URL}/api/userpermissions`,
+        payload
+      );
       if (response.data.success) {
         Swal.fire("Éxito", "Permisos actualizados correctamente", "success");
       } else {


### PR DESCRIPTION
## Summary
- replace hard-coded localhost URLs with `API_BASE_URL`
- import API config where needed

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841eab710708328bdcd69bc34bd470e