### PR TITLE
Fix AuthContext Next.js client directive

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useState, useEffect, useContext } from "react";
 
 interface AuthContextType {


### PR DESCRIPTION
## Summary
- ensure AuthContext is treated as a client component by Next.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841f11711508328bce6c53a67d04ee3