### PR TITLE
Fix API base URL sanitization

### DIFF
--- a/utils/apiConfig.ts
+++ b/utils/apiConfig.ts
@@ -1,2 +1,5 @@
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8080';
+// Sanitize the base URL to avoid duplicating the `/api` segment when the
+// environment variable already includes it.
+const envUrl = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8080';
+export const API_BASE_URL = envUrl.replace(/\/api\/?$/, '');
 


### PR DESCRIPTION
## Summary
- sanitize `API_BASE_URL` to avoid duplicated `/api`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff9efdcc8328832b237cf3093883