### PR TITLE
Fix duplicate key warning in SeguimientoPage

### DIFF
--- a/app/seguimiento/page.tsx
+++ b/app/seguimiento/page.tsx
@@ -577,8 +577,11 @@ export default function SeguimientoPage() {
                     {/* Contenedor con scroll para citas */}
                     <div className="max-h-56 overflow-y-auto space-y-2">
                       {citas.length > 0 ? (
-                        citas.map((cita) => (
-                          <div key={cita.id} className="flex justify-between items-center text-sm border-b py-2">
+                        citas.map((cita, index) => (
+                          <div
+                            key={cita.id ?? `${cita.datecita}-${index}`}
+                            className="flex justify-between items-center text-sm border-b py-2"
+                          >
                             <span>{formatDate(cita.datecita)}</span>
                             <span>{cita.descricita}</span>
                           </div>


### PR DESCRIPTION
## Summary
- ensure unique keys when rendering appointment list

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684208913b30832892e9db44a9a689f2