### PR TITLE
Fix course API payload fields

### DIFF
--- a/app/academico/programacion/page.tsx
+++ b/app/academico/programacion/page.tsx
@@ -52,7 +52,7 @@ interface Facilitator {
   id: string
   name: string
   specialty: string
-  availability: string[]
+  availability?: string[]
 }
 
 
@@ -148,8 +148,8 @@ export default function ProgramacionCursos() {
       code: formData.code,
       area: formData.area,
       credits: formData.credits,
-      start_date: formData.startDate,
-      end_date: formData.endDate,
+      startDate: formData.startDate,
+      endDate: formData.endDate,
       schedule: formData.schedule,
       duration: formData.duration,
 
@@ -488,7 +488,7 @@ export default function ProgramacionCursos() {
                               <div className="font-medium">{facilitator.name}</div>
                               <div className="text-sm text-gray-500">{facilitator.specialty}</div>
                               <div className="flex flex-wrap gap-1 mt-2">
-                                {facilitator.availability.map((day) => (
+                                {facilitator.availability?.map((day) => (
                                   <Badge key={day} variant="outline" className="text-xs">
                                     {day}
                                   </Badge>

--- a/services/courses.ts
+++ b/services/courses.ts
@@ -5,11 +5,11 @@ export interface CourseInput {
   code: string
   area: 'common' | 'specialty'
   credits: number
-  start_date: string
-  end_date: string
+  startDate: string
+  endDate: string
   schedule: string
   duration: string
-  facilitator_id?: number | null
+  facilitatorId?: number | null
 }
 
 export interface Course extends CourseInput {
@@ -47,8 +47,8 @@ export const syncCourseToMoodle = async (id: number) => {
   return res.data
 }
 
-export const assignFacilitator = async (id: number, facilitator_id: number | null) => {
-  const res = await api.post<Course>(`/courses/${id}/assign-facilitator`, { facilitator_id })
+export const assignFacilitator = async (id: number, facilitatorId: number | null) => {
+  const res = await api.post<Course>(`/courses/${id}/assign-facilitator`, { facilitatorId })
   return res.data
 }
 


### PR DESCRIPTION
## Summary
- use camelCase naming for course service payload fields
- adjust course programacion page to send camelCase fields
- make facilitator availability optional and guard map call

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427e6446788328ad2d761c3de9d18b