### PR TITLE
Add program filter for enrolled students

### DIFF
--- a/app/academico/asignacion/page.tsx
+++ b/app/academico/asignacion/page.tsx
@@ -78,6 +78,8 @@ export default function AsignacionPage() {
   const [coursesLoading, setCoursesLoading] = useState(false)
 
   const [dateRange, setDateRange] = useState<DateRange | undefined>()
+  const [programs, setPrograms] = useState<Programa[]>([])
+  const [programFilter, setProgramFilter] = useState("all")
   const searchDebounced = useDebounce(search, 300)
 
   useEffect(() => {
@@ -184,6 +186,13 @@ export default function AsignacionPage() {
       const date = new Date(p.ultimoCambio)
       const fromOk = !dateRange?.from || date >= dateRange.from
       const toOk = !dateRange?.to || date <= dateRange.to
+      const programMatch =
+        programFilter === "all" ||
+        p.programas.some((pr) => String(pr.id) === programFilter)
+
+      return termMatch && fromOk && toOk && programMatch
+    })
+  }, [prospects, searchDebounced, dateRange, programFilter])
 
   const paginatedProspects = useMemo(() => {
     const start = (page - 1) * pageSize
@@ -279,7 +288,13 @@ export default function AsignacionPage() {
               value={dateRange}
               onChange={(range) => {
                 setDateRange(range)
-
+                setPage(1)
+              }}
+            />
+            <Select
+              value={programFilter}
+              onValueChange={(val) => {
+                setProgramFilter(val)
                 setPage(1)
               }}
             >


### PR DESCRIPTION
## Summary
- keep track of available programs and selected filter in asignacion page
- filter enrolled students list by selected program
- allow selecting program from dropdown next to date range picker

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fe3bf8ac8328a658d9c2661c87ff