### PR TITLE
Fix whitespace hydration error

### DIFF
--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -31,19 +31,25 @@ const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttribut
 TableFooter.displayName = "TableFooter"
 
 const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
-  ({ className, children, ...props }, ref) => (
-    <tr
-      ref={ref}
-      className={cn(
-        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-        className,
-      )}
-      suppressHydrationWarning
-      {...props}
-    >
-      {children}
-    </tr>
-  ),
+  ({ className, children, ...props }, ref) => {
+    const filteredChildren = React.Children.toArray(children).filter(
+      (child) => !(typeof child === "string" && /^\s*$/.test(child as string)),
+    )
+
+    return (
+      <tr
+        ref={ref}
+        className={cn(
+          "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+          className,
+        )}
+        suppressHydrationWarning
+        {...props}
+      >
+        {filteredChildren}
+      </tr>
+    )
+  },
 )
 TableRow.displayName = "TableRow"
 


### PR DESCRIPTION
## Summary
- filter out whitespace-only children in TableRow to avoid hydration error

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b774104483289501c01f9d0171bb