### PR TITLE
Fetch countries from API

### DIFF
--- a/components/inscripcion/CountryCombobox.tsx
+++ b/components/inscripcion/CountryCombobox.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { cn } from "@/lib/utils"
+
+interface Props {
+  countries: string[]
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+export default function CountryCombobox({
+  countries,
+  value,
+  onChange,
+  placeholder = "Seleccione",
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+
+  const filtered = useMemo(
+    () =>
+      countries.filter((c) =>
+        c.toLowerCase().includes(search.toLowerCase()),
+      ),
+    [countries, search],
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="justify-between w-full"
+        >
+          {value ? value : placeholder}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+        <Command>
+          <CommandInput
+            placeholder="Buscar país"
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandEmpty>No hay resultados.</CommandEmpty>
+          <CommandList>
+            <CommandGroup>
+              {filtered.map((c) => (
+                <CommandItem
+                  key={c}
+                  value={c}
+                  onSelect={(v) => {
+                    onChange(v)
+                    setOpen(false)
+                  }}
+                >
+                  {c}
+                  <Check
+                    className={cn(
+                      "ml-auto h-4 w-4",
+                      value === c ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/inscripcion/tabs/PersonalTab.tsx
+++ b/components/inscripcion/tabs/PersonalTab.tsx
@@ -1,21 +1,17 @@
 "use client"
-import { useMemo } from "react"
+import { useMemo, useEffect } from "react"
 import { Search, ArrowRight, CheckCircle } from "lucide-react"
 import Swal from "sweetalert2"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import CountryCombobox from "../CountryCombobox"
 import { Label } from "@/components/ui/label"
 import { RequiredAsterisk } from "@/components/ui/required-asterisk"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+
 import { Textarea } from "@/components/ui/textarea"
 import { DatosPersonales } from "../types"
+import { useCountries } from "@/hooks/useCountries"
 
 interface Props {
   datos: DatosPersonales
@@ -30,15 +26,20 @@ export default function PersonalTab({
   openModal,
   goNext,
 }: Props) {
-  const paises = [
-    "Guatemala",
-    "El Salvador",
-    "Honduras",
-    "Nicaragua",
-    "Costa Rica",
-    "Panamá",
-    "México",
-  ]
+  const { countries } = useCountries()
+
+  // Set default countries when data is empty
+  useEffect(() => {
+    if (countries.length > 0) {
+      if (!datos.paisOrigen) {
+        setDatos((prev) => ({ ...prev, paisOrigen: "Guatemala" }))
+      }
+      if (!datos.paisResidencia) {
+        setDatos((prev) => ({ ...prev, paisResidencia: "Guatemala" }))
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [countries])
 
   // Validación de campos obligatorios con DPI de 13 dígitos
   const isFormValid = useMemo(() => {
@@ -104,43 +105,23 @@ export default function PersonalTab({
             <Label>
               País de origen <RequiredAsterisk />
             </Label>
-            <Select
+            <CountryCombobox
+              countries={countries}
               value={datos.paisOrigen || ""}
-              onValueChange={(v) => setDatos({ ...datos, paisOrigen: v })}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Seleccione" />
-              </SelectTrigger>
-              <SelectContent>
-                {paises.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              onChange={(v) => setDatos({ ...datos, paisOrigen: v })}
+            />
           </div>
           <div className="space-y-2">
             <Label>
               País de residencia <RequiredAsterisk />
             </Label>
-            <Select
+            <CountryCombobox
+              countries={countries}
               value={datos.paisResidencia || ""}
-              onValueChange={(v) =>
+              onChange={(v) =>
                 setDatos({ ...datos, paisResidencia: v })
               }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Seleccione" />
-              </SelectTrigger>
-              <SelectContent>
-                {paises.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            />
           </div>
         </div>
 

--- a/hooks/useCountries.ts
+++ b/hooks/useCountries.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export function useCountries() {
+  const [countries, setCountries] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchCountries = async () => {
+      try {
+        const res = await fetch(
+          "https://restcountries.com/v3.1/all?fields=name",
+        )
+        if (!res.ok) {
+          throw new Error(`status ${res.status}`)
+        }
+        const data = await res.json()
+        if (!Array.isArray(data)) {
+          throw new Error("unexpected response")
+        }
+        const names = data.map((c: any) => c.name.common as string)
+        names.sort((a, b) => a.localeCompare(b))
+        setCountries(names)
+      } catch (err) {
+        console.error("Error fetching countries", err)
+        setCountries(["Guatemala"])
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchCountries()
+  }, [])
+
+  return { countries, loading }
+}
+


### PR DESCRIPTION
## Summary
- fetch countries from a public API
- default registration countries to **Guatemala**
- allow filtering of country of origin
- switch to a combobox interface for selecting countries

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e3af286c832880edc206d8f9cd08