### PR TITLE
Fix create user API call

### DIFF
--- a/app/academico/usuarios/page.tsx
+++ b/app/academico/usuarios/page.tsx
@@ -21,6 +21,7 @@ import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 import { toast } from "@/hooks/use-toast"
 import { crearUsuarioEnBD } from "@/utils/crearUsuario" // Importa la utilidad nueva
+import api from "@/services/api"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL 
 
@@ -111,6 +112,42 @@ function getStatusBadgeInfo(status: string) {
   }
 }
 
+async function checkEmailExists(email: string): Promise<boolean> {
+  try {
+    const res = await api.get('/api/users', { params: { email } })
+    const data = Array.isArray(res.data)
+      ? res.data
+      : Array.isArray(res.data?.data)
+        ? res.data.data
+        : res.data
+    if (Array.isArray(data)) {
+      return data.some((u: any) => u.email === email)
+    }
+    return !!data
+  } catch (err) {
+    console.error('Error checking email', err)
+    return false
+  }
+}
+
+async function checkUsernameExists(username: string): Promise<boolean> {
+  try {
+    const res = await api.get('/api/users', { params: { username } })
+    const data = Array.isArray(res.data)
+      ? res.data
+      : Array.isArray(res.data?.data)
+        ? res.data.data
+        : res.data
+    if (Array.isArray(data)) {
+      return data.some((u: any) => u.username === username)
+    }
+    return !!data
+  } catch (err) {
+    console.error('Error checking username', err)
+    return false
+  }
+}
+
 export default function GestionUsuarios() {
   const [students, setStudents] = useState<Student[]>([])
   const [notifications, setNotifications] = useState<Notification[]>(mockNotifications)
@@ -196,6 +233,8 @@ useEffect(() => {
   
   console.log('[DEBUG] Iniciando carga de estudiantes...');
   fetchStudents();
+  const interval = setInterval(fetchStudents, 300000); // refresh cada 5 min
+  return () => clearInterval(interval);
 }, []);
 
   // Filtrar estudiantes
@@ -336,11 +375,21 @@ useEffect(() => {
     setIsGeneratingCredentials(true)
 
     try {
-      // Generar username, email y password automáticamente
-      const username = `${selectedStudent.name.toLowerCase()}.${selectedStudent.lastName.toLowerCase()}`
+      // Generar username base
+      const base = `${selectedStudent.name.toLowerCase()}.${selectedStudent.lastName.toLowerCase()}`
         .normalize("NFD")
         .replace(/[\u0300-\u036f]/g, "")
-      const institutionalEmail = `${username}@americanschool.edu.gt`
+      let username = base
+      let institutionalEmail = `${username}@americanschool.edu.gt`
+      let suffix = 1
+
+      // Verificar si el correo o el username ya existen y ajustar de ser necesario
+      while (await checkEmailExists(institutionalEmail) || await checkUsernameExists(username)) {
+        username = `${base}${suffix}`
+        institutionalEmail = `${username}@americanschool.edu.gt`
+        suffix++
+      }
+
       const password = generatePassword(selectedStudent)
 
       // Payload para la API

--- a/utils/crearUsuario.ts
+++ b/utils/crearUsuario.ts
@@ -22,18 +22,7 @@ export async function crearUsuarioEnBD(
   try {
     console.log("[DEBUG] crearUsuarioEnBD → payload:", payload)
 
-    const token = localStorage.getItem("token") || ""
-    const res = await fetch(`${API_URL}/users`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(payload),
-    })
-
-
-    const res = await api.post("/users", payload)
+    const res = await api.post("/api/users", payload)
     const body = res.data
 
     // Mostrar alerta de éxito


### PR DESCRIPTION
## Summary
- adjust axios path to `/api/users`
- check for email and username duplicates before generating credentials
- periodically refresh prospects list to remove duplicates

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac3dba5108328b78e287b2f945731