### PR TITLE
Enable multiple program selection for courses

### DIFF
--- a/components/courses-management.tsx
+++ b/components/courses-management.tsx
@@ -64,7 +64,7 @@ export function CoursesManagement() {
     endDate: formatDate(new Date().toISOString()),
     schedule: "",
     duration: "",
-    programId: null,
+    programIds: [],
     facilitatorId: null,
   })
 
@@ -116,7 +116,8 @@ export function CoursesManagement() {
     const matchArea = filterArea === "all" || c.area === filterArea
     const matchStatus = filterStatus === "all" || c.status === filterStatus
     const matchProgram =
-      filterProgram === "all" || c.program?.nombre_del_programa === filterProgram
+      filterProgram === "all" ||
+      c.programas.some((p) => p.nombre_del_programa === filterProgram)
     return matchText && matchArea && matchStatus && matchProgram
   })
   const totalPages = Math.max(1, Math.ceil(filtered.length / perPage))
@@ -136,7 +137,7 @@ export function CoursesManagement() {
       endDate: formatDate(new Date().toISOString()),
       schedule: "",
       duration: "",
-      programId: null,
+      programIds: [],
       facilitatorId: null,
     })
     setFormMode("create")
@@ -155,7 +156,7 @@ export function CoursesManagement() {
       endDate: course.endDate,
       schedule: course.schedule,
       duration: course.duration,
-      programId: course.program?.id ?? null,
+      programIds: course.programas.map((p) => p.id),
       facilitatorId: course.facilitatorId ?? null,
     })
     setFormMode("edit")
@@ -288,7 +289,9 @@ export function CoursesManagement() {
                 <TableCell>{c.name}</TableCell>
                 <TableCell>{c.area === "common" ? "Común" : "Especialidad"}</TableCell>
                 <TableCell>{c.credits}</TableCell>
-                <TableCell>{c.program?.nombre_del_programa ?? "-"}</TableCell>
+                <TableCell>
+                  {c.programas.map((p) => p.nombre_del_programa).join(', ') || '-'}
+                </TableCell>
                 <TableCell>{c.facilitator?.name ?? "-"}</TableCell>
                 <TableCell>
                   <Badge
@@ -445,24 +448,25 @@ export function CoursesManagement() {
             </div>
             <div className="space-y-2">
               <Label>Programa</Label>
-              <Select
-                value={form.programId ? String(form.programId) : "none"}
-                onValueChange={(v) =>
-                  setForm({ ...form, programId: v === "none" ? null : Number(v) })
+              <select
+                multiple
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                value={form.programIds.map(String)}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    programIds: Array.from(e.target.selectedOptions).map((o) =>
+                      Number(o.value)
+                    ),
+                  })
                 }
               >
-                <SelectTrigger>
-                  <SelectValue placeholder="Seleccione" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">Sin asignar</SelectItem>
-                  {programs.map((p) => (
-                    <SelectItem key={p.id} value={String(p.id)}>
-                      {p.nombre_del_programa}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                {programs.map((p) => (
+                  <option key={p.id} value={String(p.id)}>
+                    {p.nombre_del_programa}
+                  </option>
+                ))}
+              </select>
             </div>
             <div className="space-y-2">
               <Label>Facilitador</Label>

--- a/services/courses.ts
+++ b/services/courses.ts
@@ -9,7 +9,7 @@ export interface CourseInput {
   endDate: string
   schedule: string
   duration: string
-  programId?: number | null
+  programIds: number[]
   facilitatorId?: number | null
 }
 
@@ -17,7 +17,7 @@ export interface Course extends CourseInput {
   id: number
   status: 'draft' | 'approved' | 'synced'
   facilitator?: { id: number; name: string } | null
-  program?: { id: number; nombre_del_programa: string } | null
+  programas: { id: number; nombre_del_programa: string }[]
 }
 
 const mapCourseFromApi = (course: any): Course => ({
@@ -30,11 +30,13 @@ const mapCourseFromApi = (course: any): Course => ({
   endDate: course.end_date,
   schedule: course.schedule,
   duration: course.duration,
-  programId: course.program_id ?? null,
+  programIds: Array.isArray(course.programas)
+    ? course.programas.map((p: any) => p.id)
+    : [],
   facilitatorId: course.facilitator_id ?? null,
   status: course.status,
   facilitator: course.facilitator ?? null,
-  program: course.program ?? null,
+  programas: course.programas ?? [],
 })
 
 const mapCourseToApi = (data: Partial<CourseInput> & { status?: Course['status'] }) => {
@@ -47,7 +49,7 @@ const mapCourseToApi = (data: Partial<CourseInput> & { status?: Course['status']
   if (data.endDate !== undefined) payload.end_date = data.endDate
   if (data.schedule !== undefined) payload.schedule = data.schedule
   if (data.duration !== undefined) payload.duration = data.duration
-  if (data.programId !== undefined) payload.program_id = data.programId
+  if (data.programIds !== undefined) payload.program_ids = data.programIds
   if (data.facilitatorId !== undefined) payload.facilitator_id = data.facilitatorId
   if ((data as any).status !== undefined) payload.status = (data as any).status
   return payload


### PR DESCRIPTION
## Summary
- update course service to use `programIds` array and map `programas`
- adjust courses management to handle multiple program selection and display joined program names

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607042a48083289791fa846d9e7324