### PR TITLE
Add closure course area

### DIFF
--- a/app/academico/asignacion/page.tsx
+++ b/app/academico/asignacion/page.tsx
@@ -73,7 +73,7 @@ export default function AsignacionPage() {
   const [selectedProspectIds, setSelectedProspectIds] = useState<string[]>([])
   const [selectedCourseIds, setSelectedCourseIds] = useState<number[]>([])
   const [courseSearch, setCourseSearch] = useState("")
-  const [courseArea, setCourseArea] = useState("all")
+  const [courseArea, setCourseArea] = useState<'all' | 'common' | 'specialty' | 'closure'>("all")
   const [courseStatus, setCourseStatus] = useState("all")
   const [coursePage, setCoursePage] = useState(1)
   const coursePageSize = 10
@@ -447,6 +447,7 @@ export default function AsignacionPage() {
               <option value="all">Todas áreas</option>
               <option value="common">Común</option>
               <option value="specialty">Especialidad</option>
+              <option value="closure">Cierre del Programa</option>
             </select>
             <select
               className="border rounded p-2 text-sm"

--- a/components/courses-management.tsx
+++ b/components/courses-management.tsx
@@ -35,6 +35,12 @@ interface ProgramOption {
   nombre_del_programa: string
 }
 
+const areaLabels: Record<'common' | 'specialty' | 'closure', string> = {
+  common: 'Común',
+  specialty: 'Especialidad',
+  closure: 'Cierre del Programa',
+}
+
 const reactSelectStyles = {
   control: (base: any) => ({
     ...base,
@@ -83,7 +89,7 @@ export function CoursesManagement() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState("")
-  const [filterArea, setFilterArea] = useState<string>("all")
+  const [filterArea, setFilterArea] = useState<'all' | 'common' | 'specialty' | 'closure'>("all")
   const [filterStatus, setFilterStatus] = useState<string>("all")
   const [filterPrograms, setFilterPrograms] = useState<number[]>([])
   const [page, setPage] = useState(1)
@@ -282,6 +288,7 @@ export function CoursesManagement() {
               <SelectItem value="all">Todas</SelectItem>
               <SelectItem value="common">Común</SelectItem>
               <SelectItem value="specialty">Especialidad</SelectItem>
+              <SelectItem value="closure">Cierre del Programa</SelectItem>
             </SelectContent>
           </Select>
           <Select value={filterStatus} onValueChange={(v) => { setFilterStatus(v); setPage(1) }}>
@@ -337,7 +344,11 @@ export function CoursesManagement() {
               <TableRow key={c.id} className="hover:bg-gray-50">
                 <TableCell>{c.code}</TableCell>
                 <TableCell>{c.name}</TableCell>
-                <TableCell>{c.area === "common" ? "Común" : "Especialidad"}</TableCell>
+                <TableCell>
+                  <Badge variant={c.area === 'common' ? 'secondary' : c.area === 'specialty' ? 'default' : 'outline'}>
+                    {areaLabels[c.area]}
+                  </Badge>
+                </TableCell>
                 <TableCell>{c.credits}</TableCell>
                 <TableCell>
                   {c.programas.map((p) => p.nombre_del_programa).join(', ') || '-'}
@@ -461,6 +472,7 @@ export function CoursesManagement() {
                 <SelectContent>
                   <SelectItem value="common">Común</SelectItem>
                   <SelectItem value="specialty">Especialidad</SelectItem>
+                  <SelectItem value="closure">Cierre del Programa</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/services/courses.ts
+++ b/services/courses.ts
@@ -3,7 +3,7 @@ import api from './api'
 export interface CourseInput {
   name: string
   code: string
-  area: 'common' | 'specialty'
+  area: 'common' | 'specialty' | 'closure'
   credits: number
   startDate: string
   endDate: string


### PR DESCRIPTION
## Summary
- add new course area `closure`
- display course area with badges
- support filtering and editing courses by area

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860dc42cefc8328996bf384de07b7e0