### PR TITLE
Add demo course assignment dashboard

### DIFF
--- a/app/academico/asignacion/simple/page.tsx
+++ b/app/academico/asignacion/simple/page.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import { useState } from "react"
+import { DndProvider } from "react-dnd"
+import { HTML5Backend } from "react-dnd-html5-backend"
+import { StudentsView } from "@/components/views/students-view"
+import { StudentAssignmentView } from "@/components/views/student-assignment-view"
+import { Button } from "@/components/ui/button"
+import { ArrowLeft } from "lucide-react"
+
+export interface Course {
+  id: string
+  name: string
+  code: string
+  type: "Básico" | "Optativo" | "Especialización"
+  description: string
+}
+
+export interface Student {
+  id: string
+  name: string
+  carnet: string
+  program: string
+  specialty: string
+  assignedCourses: string[]
+  completedCourses: string[]
+}
+
+const initialCourses: Course[] = [
+  { id: "1", name: "Estadística I", code: "EST101", type: "Básico", description: "Fundamentos de estadística" },
+  { id: "2", name: "Finanzas I", code: "FIN101", type: "Básico", description: "Principios de finanzas" },
+  { id: "3", name: "Marketing Digital", code: "MKT201", type: "Optativo", description: "Estrategias de marketing digital" },
+  { id: "4", name: "Liderazgo", code: "LID301", type: "Especialización", description: "Desarrollo de liderazgo" },
+  { id: "5", name: "Planeación Estratégica", code: "PLA301", type: "Especialización", description: "Planificación empresarial" },
+  { id: "6", name: "Matemática", code: "MAT101", type: "Básico", description: "Matemáticas básicas" },
+  { id: "7", name: "Física", code: "FIS101", type: "Básico", description: "Principios de física" },
+  { id: "8", name: "Sociales", code: "SOC101", type: "Optativo", description: "Ciencias sociales" },
+]
+
+const initialStudents: Student[] = [
+  {
+    id: "1",
+    name: "Juan Pérez",
+    carnet: "2024001",
+    program: "Ingeniería",
+    specialty: "Sistemas",
+    assignedCourses: ["1", "6"],
+    completedCourses: ["2"],
+  },
+  {
+    id: "2",
+    name: "Byron Caal",
+    carnet: "2024002",
+    program: "MBA",
+    specialty: "Administración",
+    assignedCourses: ["6", "7"],
+    completedCourses: ["8", "3"],
+  },
+  {
+    id: "3",
+    name: "María González",
+    carnet: "2024003",
+    program: "Ingeniería",
+    specialty: "Industrial",
+    assignedCourses: ["2"],
+    completedCourses: ["4"],
+  },
+  {
+    id: "4",
+    name: "Carlos López",
+    carnet: "2024004",
+    program: "Ingeniería",
+    specialty: "Sistemas",
+    assignedCourses: ["3"],
+    completedCourses: ["1"],
+  },
+  {
+    id: "5",
+    name: "Ana Rodríguez",
+    carnet: "2024005",
+    program: "MBA",
+    specialty: "Finanzas",
+    assignedCourses: ["4"],
+    completedCourses: ["2", "6"],
+  },
+]
+
+export default function CourseAssignmentDashboard() {
+  const [students, setStudents] = useState<Student[]>(initialStudents)
+  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
+  const [currentView, setCurrentView] = useState<"main" | "assignment">("main")
+
+  const handleCourseAssignment = (studentId: string, courseId: string, isAssigned: boolean) => {
+    setStudents(prev =>
+      prev.map(student => {
+        if (student.id === studentId) {
+          const updatedCourses = isAssigned
+            ? [...student.assignedCourses, courseId]
+            : student.assignedCourses.filter(id => id !== courseId)
+          return { ...student, assignedCourses: updatedCourses }
+        }
+        return student
+      })
+    )
+  }
+
+  const handleBulkAssignment = (studentIds: string[], courseIds: string[], isAssigned: boolean) => {
+    setStudents(prev =>
+      prev.map(student => {
+        if (studentIds.includes(student.id)) {
+          let updated = [...student.assignedCourses]
+          courseIds.forEach(courseId => {
+            if (isAssigned) {
+              if (!updated.includes(courseId)) updated.push(courseId)
+            } else {
+              updated = updated.filter(id => id !== courseId)
+            }
+          })
+          return { ...student, assignedCourses: updated }
+        }
+        return student
+      })
+    )
+  }
+
+  const handleViewAssignment = (studentId: string) => {
+    setSelectedStudentId(studentId)
+    setCurrentView("assignment")
+  }
+
+  const handleBackToMain = () => {
+    setCurrentView("main")
+    setSelectedStudentId(null)
+  }
+
+  const selectedStudent = selectedStudentId ? students.find(s => s.id === selectedStudentId) : null
+
+  if (currentView === "assignment" && selectedStudent) {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <div className="min-h-screen bg-gray-100">
+          <div className="container mx-auto p-4">
+            <div className="mb-6">
+              <Button onClick={handleBackToMain} variant="outline" className="mb-4 bg-transparent">
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Volver a Estudiantes
+              </Button>
+              <h1 className="text-3xl font-bold">Asignación de Cursos - {selectedStudent.name}</h1>
+            </div>
+            <StudentAssignmentView
+              student={selectedStudent}
+              courses={initialCourses}
+              onCourseAssignment={handleCourseAssignment}
+            />
+          </div>
+        </div>
+      </DndProvider>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <div className="container mx-auto p-4">
+        <h1 className="text-3xl font-bold text-center mb-6">Dashboard de Gestión de Inscripciones</h1>
+        <StudentsView
+          students={students}
+          courses={initialCourses}
+          onViewAssignment={handleViewAssignment}
+          onBulkAssignment={handleBulkAssignment}
+        />
+      </div>
+    </div>
+  )
+}
+

--- a/components/bulk-assignment-panel.tsx
+++ b/components/bulk-assignment-panel.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useState } from "react"
+import type { Student, Course } from "@/academico/asignacion/simple/page"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { X, Users, BookOpen, Plus, Minus } from "lucide-react"
+
+interface BulkAssignmentPanelProps {
+  selectedStudents: Student[]
+  courses: Course[]
+  onBulkAssignment: (studentIds: string[], courseIds: string[], isAssigned: boolean) => void
+  onClose: () => void
+}
+
+export function BulkAssignmentPanel({ selectedStudents, courses, onBulkAssignment, onClose }: BulkAssignmentPanelProps) {
+  const [selectedCourses, setSelectedCourses] = useState<string[]>([])
+
+  const handleCourseSelect = (courseId: string, isSelected: boolean) => {
+    if (isSelected) {
+      setSelectedCourses((prev) => [...prev, courseId])
+    } else {
+      setSelectedCourses((prev) => prev.filter((id) => id !== courseId))
+    }
+  }
+
+  const handleBulkAssign = () => {
+    if (selectedCourses.length > 0) {
+      onBulkAssignment(
+        selectedStudents.map((s) => s.id),
+        selectedCourses,
+        true
+      )
+      onClose()
+    }
+  }
+
+  const handleBulkUnassign = () => {
+    if (selectedCourses.length > 0) {
+      onBulkAssignment(
+        selectedStudents.map((s) => s.id),
+        selectedCourses,
+        false
+      )
+      onClose()
+    }
+  }
+
+  const getTypeColor = (type: Course["type"]) => {
+    switch (type) {
+      case "Básico":
+        return "bg-blue-500"
+      case "Optativo":
+        return "bg-green-500"
+      case "Especialización":
+        return "bg-purple-500"
+      default:
+        return "bg-gray-500"
+    }
+  }
+
+  return (
+    <Card className="border-2 border-blue-200">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <Users className="h-5 w-5" />
+            <span>Asignación Masiva</span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <h4 className="font-medium mb-2">Estudiantes Seleccionados ({selectedStudents.length})</h4>
+          <div className="flex flex-wrap gap-2">
+            {selectedStudents.map((student) => (
+              <Badge key={student.id} variant="secondary">
+                {student.name}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h4 className="font-medium mb-2 flex items-center">
+            <BookOpen className="h-4 w-4 mr-2" />
+            Seleccionar Cursos ({selectedCourses.length} seleccionados)
+          </h4>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 max-h-60 overflow-y-auto">
+            {courses.map((course) => (
+              <div key={course.id} className="flex items-center space-x-2 p-2 border rounded">
+                <Checkbox
+                  checked={selectedCourses.includes(course.id)}
+                  onCheckedChange={(checked) => handleCourseSelect(course.id, checked as boolean)}
+                />
+                <div className="flex-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-sm">{course.name}</span>
+                    <Badge className={`${getTypeColor(course.type)} text-white text-xs`}>{course.type}</Badge>
+                  </div>
+                  <p className="text-xs text-gray-500">{course.code}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex space-x-2 pt-4">
+          <Button onClick={handleBulkAssign} disabled={selectedCourses.length === 0} className="flex-1">
+            <Plus className="h-4 w-4 mr-2" />
+            Asignar Cursos
+          </Button>
+          <Button
+            onClick={handleBulkUnassign}
+            disabled={selectedCourses.length === 0}
+            variant="outline"
+            className="flex-1 bg-transparent"
+          >
+            <Minus className="h-4 w-4 mr-2" />
+            Desasignar Cursos
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/cards/student-card.tsx
+++ b/components/cards/student-card.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import type { Student } from "@/academico/asignacion/simple/page"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { User, Settings, Award, BookOpen } from "lucide-react"
+
+interface StudentCardProps {
+  student: Student
+  isSelected: boolean
+  onSelect: (studentId: string, isSelected: boolean) => void
+  onViewAssignment: (studentId: string) => void
+}
+
+export function StudentCard({ student, isSelected, onSelect, onViewAssignment }: StudentCardProps) {
+  return (
+    <Card className={`hover:shadow-md transition-shadow ${isSelected ? "ring-2 ring-blue-500" : ""}`}>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between mb-3">
+          <div className="flex items-center space-x-2">
+            <Checkbox checked={isSelected} onCheckedChange={(checked) => onSelect(student.id, checked as boolean)} />
+            <User className="h-5 w-5 text-blue-600" />
+            <h3 className="font-semibold text-lg">{student.name}</h3>
+          </div>
+          <Badge variant="outline">{student.carnet}</Badge>
+        </div>
+
+        <div className="space-y-2 text-sm text-gray-600 mb-4">
+          <div>
+            <span className="font-medium">Programa:</span> {student.program}
+          </div>
+          <div>
+            <span className="font-medium">Especialidad:</span> {student.specialty}
+          </div>
+          <div className="flex justify-between">
+            <div className="flex items-center space-x-1">
+              <BookOpen className="h-4 w-4" />
+              <span>Asignados: {student.assignedCourses.length}</span>
+            </div>
+            <div className="flex items-center space-x-1">
+              <Award className="h-4 w-4" />
+              <span>Completados: {student.completedCourses.length}</span>
+            </div>
+          </div>
+        </div>
+
+        <Button onClick={() => onViewAssignment(student.id)} className="w-full">
+          <Settings className="h-4 w-4 mr-2" />
+          Asignar Cursos
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -1,0 +1,267 @@
+"use client"
+
+import { useState } from "react"
+import { useDrag, useDrop } from "react-dnd"
+import type { Student, Course } from "@/academico/asignacion/simple/page"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Check, X, GripVertical, Save, User, BookOpen, Award } from "lucide-react"
+import type React from "react"
+
+interface StudentAssignmentViewProps {
+  student: Student
+  courses: Course[]
+  onCourseAssignment: (studentId: string, courseId: string, isAssigned: boolean) => void
+}
+
+interface DraggableCourseProps {
+  course: Course
+  status: "assigned" | "available" | "completed"
+}
+
+const DraggableCourse = ({ course, status }: DraggableCourseProps) => {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: "course",
+    item: { courseId: course.id, status },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  }))
+
+  const getTypeColor = (type: Course["type"]) => {
+    switch (type) {
+      case "Básico":
+        return "bg-blue-500"
+      case "Optativo":
+        return "bg-green-500"
+      case "Especialización":
+        return "bg-purple-500"
+      default:
+        return "bg-gray-500"
+    }
+  }
+
+  const getStatusStyle = () => {
+    switch (status) {
+      case "assigned":
+        return "bg-yellow-50 border-yellow-200 hover:bg-yellow-100"
+      case "available":
+        return "bg-blue-50 border-blue-200 hover:bg-blue-100"
+      case "completed":
+        return "bg-green-50 border-green-200 hover:bg-green-100"
+      default:
+        return "bg-gray-50 border-gray-200"
+    }
+  }
+
+  const getStatusIcon = () => {
+    switch (status) {
+      case "assigned":
+        return <Check className="h-4 w-4 text-yellow-600" />
+      case "completed":
+        return <Award className="h-4 w-4 text-green-600" />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Card
+      ref={status !== "completed" ? drag : undefined}
+      className={`transition-all duration-200 ${status !== "completed" ? "cursor-move" : "cursor-not-allowed opacity-75"} ${isDragging ? "opacity-50 scale-95" : ""} ${getStatusStyle()}`}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center space-x-2">
+            {status !== "completed" && <GripVertical className="h-4 w-4 text-gray-400" />}
+            {getStatusIcon()}
+            <span className="font-medium">{course.name}</span>
+          </div>
+          <Badge className={`${getTypeColor(course.type)} text-white text-xs`}>{course.type}</Badge>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-600">{course.code}</span>
+          <BookOpen className="h-4 w-4 text-gray-400" />
+        </div>
+        <p className="text-xs text-gray-500 mt-1">{course.description}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface DropZoneProps {
+  status: "assigned" | "available"
+  onDrop: (courseId: string, toStatus: "assigned" | "available") => void
+  children: React.ReactNode
+  title: string
+  count: number
+  icon: React.ReactNode
+}
+
+const DropZone = ({ status, onDrop, children, title, count, icon }: DropZoneProps) => {
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: "course",
+    drop: (item: { courseId: string; status: "assigned" | "available" | "completed" }) => {
+      if (item.status !== status && item.status !== "completed") {
+        onDrop(item.courseId, status)
+      }
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+    }),
+  }))
+
+  const getDropZoneStyle = () => {
+    const base = "min-h-[400px] p-6 rounded-lg border-2 border-dashed transition-all duration-200"
+    if (isOver) {
+      return status === "assigned" ? `${base} border-yellow-400 bg-yellow-50` : `${base} border-blue-400 bg-blue-50`
+    }
+    return status === "assigned" ? `${base} border-yellow-200 bg-yellow-25` : `${base} border-blue-200 bg-blue-25`
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className={`font-semibold text-lg flex items-center ${status === "assigned" ? "text-yellow-700" : "text-blue-700"}`}>{icon}{title}</h3>
+        <Badge variant="outline" className="text-sm">
+          {count} cursos
+        </Badge>
+      </div>
+
+      <div ref={drop} className={getDropZoneStyle()}>
+        <div className="space-y-3">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+export function StudentAssignmentView({ student, courses, onCourseAssignment }: StudentAssignmentViewProps) {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+
+  const assignedCourses = courses.filter((course) => student.assignedCourses.includes(course.id))
+  const completedCourses = courses.filter((course) => student.completedCourses.includes(course.id))
+  const availableCourses = courses.filter(
+    (course) => !student.assignedCourses.includes(course.id) && !student.completedCourses.includes(course.id)
+  )
+
+  const handleCourseDrop = (courseId: string, toStatus: "assigned" | "available") => {
+    const isAssigned = toStatus === "assigned"
+    onCourseAssignment(student.id, courseId, isAssigned)
+    setHasUnsavedChanges(true)
+  }
+
+  const handleSaveChanges = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    setHasUnsavedChanges(false)
+    alert("Cambios guardados exitosamente")
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-3">
+            <User className="h-6 w-6 text-blue-600" />
+            <div>
+              <span className="text-2xl">{student.name}</span>
+              <Badge variant="outline" className="ml-3">
+                {student.carnet}
+              </Badge>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+            <div>
+              <span className="font-medium text-gray-600">Programa:</span>
+              <p className="text-gray-900">{student.program}</p>
+            </div>
+            <div>
+              <span className="font-medium text-gray-600">Especialidad:</span>
+              <p className="text-gray-900">{student.specialty}</p>
+            </div>
+            <div>
+              <span className="font-medium text-gray-600">Cursos Activos:</span>
+              <p className="text-gray-900">{assignedCourses.length}</p>
+            </div>
+            <div>
+              <span className="font-medium text-gray-600">Cursos Completados:</span>
+              <p className="text-gray-900">{completedCourses.length}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <DropZone
+          status="assigned"
+          onDrop={handleCourseDrop}
+          title="Cursos Asignados"
+          count={assignedCourses.length}
+          icon={<Check className="h-5 w-5 mr-2" />}
+        >
+          {assignedCourses.length === 0 ? (
+            <div className="text-center py-12">
+              <BookOpen className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+              <p className="text-gray-500">Arrastra cursos aquí para asignar</p>
+            </div>
+          ) : (
+            assignedCourses.map((course) => <DraggableCourse key={course.id} course={course} status="assigned" />)
+          )}
+        </DropZone>
+
+        <DropZone
+          status="available"
+          onDrop={handleCourseDrop}
+          title="Cursos Disponibles"
+          count={availableCourses.length}
+          icon={<X className="h-5 w-5 mr-2" />}
+        >
+          {availableCourses.length === 0 ? (
+            <div className="text-center py-12">
+              <Check className="h-12 w-12 text-green-300 mx-auto mb-4" />
+              <p className="text-gray-500">Todos los cursos están asignados o completados</p>
+            </div>
+          ) : (
+            availableCourses.map((course) => <DraggableCourse key={course.id} course={course} status="available" />)
+          )}
+        </DropZone>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-lg flex items-center text-green-700">
+              <Award className="h-5 w-5 mr-2" />
+              Cursos Completados
+            </h3>
+            <Badge variant="outline" className="text-sm">
+              {completedCourses.length} cursos
+            </Badge>
+          </div>
+
+          <div className="min-h-[400px] p-6 rounded-lg border-2 border-solid border-green-200 bg-green-25">
+            <div className="space-y-3">
+              {completedCourses.length === 0 ? (
+                <div className="text-center py-12">
+                  <Award className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+                  <p className="text-gray-500">No hay cursos completados</p>
+                </div>
+              ) : (
+                completedCourses.map((course) => <DraggableCourse key={course.id} course={course} status="completed" />)
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {hasUnsavedChanges && (
+        <div className="fixed bottom-6 right-6">
+          <Button onClick={handleSaveChanges} size="lg" className="shadow-lg">
+            <Save className="h-4 w-4 mr-2" />
+            Guardar Cambios
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/views/students-view.tsx
+++ b/components/views/students-view.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useState } from "react"
+import type { Student, Course } from "@/academico/asignacion/simple/page"
+import { StudentCard } from "@/components/cards/student-card"
+import { BulkAssignmentPanel } from "@/components/bulk-assignment-panel"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { Users, Search, Filter, Settings } from "lucide-react"
+
+interface StudentsViewProps {
+  students: Student[]
+  courses: Course[]
+  onViewAssignment: (studentId: string) => void
+  onBulkAssignment: (studentIds: string[], courseIds: string[], isAssigned: boolean) => void
+}
+
+export function StudentsView({ students, courses, onViewAssignment, onBulkAssignment }: StudentsViewProps) {
+  const [searchTerm, setSearchTerm] = useState("")
+  const [filterProgram, setFilterProgram] = useState<string>("all")
+  const [filterSpecialty, setFilterSpecialty] = useState<string>("all")
+  const [selectedStudents, setSelectedStudents] = useState<string[]>([])
+  const [showBulkPanel, setShowBulkPanel] = useState(false)
+
+  const programs = Array.from(new Set(students.map((s) => s.program)))
+  const specialties = Array.from(new Set(students.map((s) => s.specialty)))
+
+  const filteredStudents = students.filter((student) => {
+    const matchesSearch = student.name.toLowerCase().includes(searchTerm.toLowerCase()) || student.carnet.includes(searchTerm)
+    const matchesProgram = filterProgram === "all" || student.program === filterProgram
+    const matchesSpecialty = filterSpecialty === "all" || student.specialty === filterSpecialty
+    return matchesSearch && matchesProgram && matchesSpecialty
+  })
+
+  const handleStudentSelect = (studentId: string, isSelected: boolean) => {
+    if (isSelected) {
+      setSelectedStudents((prev) => [...prev, studentId])
+    } else {
+      setSelectedStudents((prev) => prev.filter((id) => id !== studentId))
+    }
+  }
+
+  const handleSelectAll = () => {
+    if (selectedStudents.length === filteredStudents.length) {
+      setSelectedStudents([])
+    } else {
+      setSelectedStudents(filteredStudents.map((s) => s.id))
+    }
+  }
+
+  const clearFilters = () => {
+    setSearchTerm("")
+    setFilterProgram("all")
+    setFilterSpecialty("all")
+    setSelectedStudents([])
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div className="flex items-center space-x-2">
+          <Users className="h-6 w-6 text-blue-600" />
+          <h2 className="text-2xl font-bold">Estudiantes ({filteredStudents.length})</h2>
+          {selectedStudents.length > 0 && <Badge variant="secondary">{selectedStudents.length} seleccionados</Badge>}
+        </div>
+        {selectedStudents.length > 0 && (
+          <Button onClick={() => setShowBulkPanel(true)} variant="outline">
+            <Settings className="h-4 w-4 mr-2" />
+            Asignación Masiva
+          </Button>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2">
+            <Filter className="h-5 w-5" />
+            <span>Filtros y Búsqueda</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                placeholder="Buscar por nombre o carnet..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            <Select value={filterProgram} onValueChange={setFilterProgram}>
+              <SelectTrigger>
+                <SelectValue placeholder="Filtrar por programa" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos los programas</SelectItem>
+                {programs.map((program) => (
+                  <SelectItem key={program} value={program}>
+                    {program}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={filterSpecialty} onValueChange={setFilterSpecialty}>
+              <SelectTrigger>
+                <SelectValue placeholder="Filtrar por especialidad" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todas las especialidades</SelectItem>
+                {specialties.map((specialty) => (
+                  <SelectItem key={specialty} value={specialty}>
+                    {specialty}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="flex space-x-2">
+              <Button variant="outline" onClick={handleSelectAll} className="flex-1 bg-transparent">
+                {selectedStudents.length === filteredStudents.length ? "Deseleccionar" : "Seleccionar"} Todo
+              </Button>
+              <Button variant="ghost" onClick={clearFilters}>
+                Limpiar
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {showBulkPanel && (
+        <BulkAssignmentPanel
+          selectedStudents={selectedStudents.map((id) => students.find((s) => s.id === id)!)}
+          courses={courses}
+          onBulkAssignment={onBulkAssignment}
+          onClose={() => setShowBulkPanel(false)}
+        />
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredStudents.map((student) => (
+          <StudentCard
+            key={student.id}
+            student={student}
+            isSelected={selectedStudents.includes(student.id)}
+            onSelect={handleStudentSelect}
+            onViewAssignment={onViewAssignment}
+          />
+        ))}
+      </div>
+
+      {filteredStudents.length === 0 && (
+        <Card>
+          <CardContent className="text-center py-12">
+            <Users className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+            <h3 className="text-lg font-medium text-gray-900 mb-2">No se encontraron estudiantes</h3>
+            <p className="text-gray-500">Intenta ajustar los filtros de búsqueda</p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create a demo page for manual course assignment
- add StudentCard component
- add StudentsView and StudentAssignmentView with drag&drop
- support bulk course assignment with BulkAssignmentPanel

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c8ec535483289586ff6ad14a0582