### PR TITLE
Use API_BASE_URL in axios config

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
+import { API_BASE_URL } from '@/utils/apiConfig';
 
 // Create axios instance with environment variable
 export const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: `${API_BASE_URL}/api`,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- create axios instance using API_BASE_URL in `services/api.ts`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621ee12c6083288e302c24274780bf