### PR TITLE
Fix fetchEnrolledStudents program handling

### DIFF
--- a/services/students.ts
+++ b/services/students.ts
@@ -14,19 +14,22 @@ export interface Student {
 export const fetchEnrolledStudents = async (): Promise<Student[]> => {
   const res = await api.get('/prospectos/status/Inscrito', { params: { per_page: 9999 } })
   const data = Array.isArray(res.data.data) ? res.data.data : res.data
-  return data.map((p: any) => {
-    const prog = Array.isArray(p.programas) && p.programas.length > 0 ? p.programas[0] : null
-    return {
-      id: String(p.id),
-      name: p.nombre_completo ?? '',
-      carnet: String(p.id),
-      programId: prog?.id ?? 0,
-      program: prog?.nombre_del_programa ?? '',
-      specialty: prog?.abreviatura ?? '',
-      assignedCourses: Array.isArray(p.courses) ? p.courses.map((c: any) => String(c.id)) : [],
-      completedCourses: [],
-    }
-  })
+  return data
+    .map((p: any) => {
+      const prog = Array.isArray(p.programas) && p.programas.length > 0 ? p.programas[0] : null
+      if (!prog) return null
+      return {
+        id: String(p.id),
+        name: p.nombre_completo ?? '',
+        carnet: String(p.id),
+        programId: prog.id,
+        program: prog.nombre_del_programa,
+        specialty: prog.abreviatura ?? '',
+        assignedCourses: Array.isArray(p.courses) ? p.courses.map((c: any) => String(c.id)) : [],
+        completedCourses: [],
+      }
+    })
+    .filter(Boolean)
 }
 
 export const assignCourses = async (studentIds: string[], courseIds: string[]) => {


### PR DESCRIPTION
## Summary
- ensure students only returned when program data exists
- filter null students out of fetchEnrolledStudents

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621edeabe483288a4813c29592762b