### PR TITLE
Handle 404 error in student program service

### DIFF
--- a/services/students.ts
+++ b/services/students.ts
@@ -15,11 +15,17 @@ export interface Student {
 export const fetchStudentProgram = async (
   studentId: string,
 ): Promise<Program | null> => {
+  try {
+    const res = await api.get(`/estudiante-programa/${studentId}`)
 
-  const res = await api.get(`/estudiante-programa/${studentId}`)
-
-  const data = Array.isArray(res.data) ? res.data : res.data.data
-  return data && data.length > 0 ? data[0] : null
+    const data = Array.isArray(res.data) ? res.data : res.data.data
+    return data && data.length > 0 ? data[0] : null
+  } catch (err: any) {
+    if (err.response?.status === 404) {
+      return null
+    }
+    throw err
+  }
 }
 
 export const fetchEnrolledStudents = async (): Promise<Student[]> => {


### PR DESCRIPTION
## Summary
- handle missing program records in `fetchStudentProgram`

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b13a11908328af48ce27194fde45