### PR TITLE
Fix course list fetch for StudentAssignmentView

### DIFF
--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -1,118 +1,85 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import type { Student } from "@/services/students";
 import type { Course } from "@/services/courses";
 import {
+  fetchStudentCourseLists,
   assignCourses,
   unassignCourses,
-  fetchStudentCourseLists,
 } from "@/services/students";
-import { fetchCourses } from "@/services/courses";
+import { fetchStudentCourses } from "@/services/courses";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
-  Check,
-  X,
-  GripVertical,
   Award,
   BookOpen,
   Calendar,
+  Check,
+  GripVertical,
   User,
+  X,
 } from "lucide-react";
 
 interface StudentAssignmentViewProps {
   student: Student;
 }
 
-interface DraggableCourseProps {
+interface CourseCardProps {
   course: Course;
   status: "assigned" | "available" | "completed";
 }
 
-const DraggableCourse = ({ course, status }: DraggableCourseProps) => {
+const CourseCard = ({ course, status }: CourseCardProps) => {
   const [{ isDragging }, drag] = useDrag(() => ({
     type: "course",
     item: { course, status },
+    canDrag: status !== "completed",
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
   }));
 
-  const getTypeColor = (area: Course["area"]) => {
-    switch (area) {
-      case "common":
-        return "bg-blue-500";
-      case "specialty":
-        return "bg-green-500";
-      case "closure":
-        return "bg-purple-500";
-      default:
-        return "bg-gray-500";
-    }
+  const areaColors: Record<Course["area"], string> = {
+    common: "bg-blue-500",
+    specialty: "bg-green-500",
+    closure: "bg-purple-500",
   };
 
-  const getTypeLabel = (area: Course["area"]) => {
-    switch (area) {
-      case "common":
-        return "Común";
-      case "specialty":
-        return "Especialidad";
-      case "closure":
-        return "Cierre";
-      default:
-        return "";
-    }
+  const areaLabels: Record<Course["area"], string> = {
+    common: "Común",
+    specialty: "Especialidad",
+    closure: "Cierre",
   };
 
-  const getStatusStyle = () => {
-    switch (status) {
-      case "assigned":
-        return "bg-yellow-50 border-yellow-200 hover:bg-yellow-100";
-      case "available":
-        return "bg-blue-50 border-blue-200 hover:bg-blue-100";
-      case "completed":
-        return "bg-green-50 border-green-200 hover:bg-green-100";
-      default:
-        return "bg-gray-50 border-gray-200";
-    }
-  };
+  const statusClasses =
+    status === "assigned"
+      ? "bg-yellow-50 border-yellow-200 hover:bg-yellow-100"
+      : status === "available"
+      ? "bg-blue-50 border-blue-200 hover:bg-blue-100"
+      : "bg-green-50 border-green-200";
 
-  const getStatusIcon = () => {
-    switch (status) {
-      case "assigned":
-        return <Check className="h-4 w-4 text-yellow-600" />;
-      case "completed":
-        return <Award className="h-4 w-4 text-green-600" />;
-      default:
-        return null;
-    }
-  };
-
-  const cardRef = useRef<HTMLDivElement>(null)
-  if (status !== "completed") {
-    drag(cardRef)
-  }
+  const ref = useRef<HTMLDivElement>(null);
+  if (status !== "completed") drag(ref);
 
   return (
     <Card
-      ref={status !== "completed" ? cardRef : undefined}
-      className={`transition-all duration-200 ${status !== "completed" ? "cursor-move" : "cursor-not-allowed opacity-75"} ${isDragging ? "opacity-50 scale-95" : ""} ${getStatusStyle()}`}
+      ref={status !== "completed" ? (ref as any) : undefined}
+      className={`border transition-all duration-200 ${status !== "completed" ? "cursor-move" : "cursor-not-allowed opacity-75"} ${isDragging ? "opacity-50" : ""} ${statusClasses}`}
     >
       <CardContent className="p-4">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center space-x-2">
-            {status !== "completed" && (
-              <GripVertical className="h-4 w-4 text-gray-400" />
-            )}
-            {getStatusIcon()}
+            {status !== "completed" && <GripVertical className="h-4 w-4 text-gray-400" />}
+            {status === "assigned" && <Check className="h-4 w-4 text-yellow-600" />}
+            {status === "completed" && <Award className="h-4 w-4 text-green-600" />}
             <span className="font-medium">{course.name}</span>
           </div>
-          <Badge className={`${getTypeColor(course.area)} text-white text-xs`}>
-            {getTypeLabel(course.area)}
+          <Badge className={`${areaColors[course.area]} text-white text-xs`}>
+            {areaLabels[course.area]}
           </Badge>
         </div>
         <div className="flex justify-between items-center">
@@ -127,21 +94,14 @@ const DraggableCourse = ({ course, status }: DraggableCourseProps) => {
 
 interface DropZoneProps {
   status: "assigned" | "available";
-  onDrop: (course: Course, toStatus: "assigned" | "available") => void;
-  children: React.ReactNode;
+  onDrop: (course: Course, to: "assigned" | "available") => void;
   title: string;
   count: number;
   icon: React.ReactNode;
+  children: React.ReactNode;
 }
 
-const DropZone = ({
-  status,
-  onDrop,
-  children,
-  title,
-  count,
-  icon,
-}: DropZoneProps) => {
+const DropZone = ({ status, onDrop, title, count, icon, children }: DropZoneProps) => {
   const [{ isOver }, drop] = useDrop(() => ({
     accept: "course",
     drop: (item: { course: Course; status: "assigned" | "available" | "completed" }) => {
@@ -149,26 +109,20 @@ const DropZone = ({
         onDrop(item.course, status);
       }
     },
-    collect: (monitor) => ({
-      isOver: monitor.isOver(),
-    }),
+    collect: (monitor) => ({ isOver: monitor.isOver() }),
   }));
 
-  const getDropZoneStyle = () => {
-    const base =
-      "min-h-[400px] p-6 rounded-lg border-2 border-dashed transition-all duration-200";
-    if (isOver) {
-      return status === "assigned"
-        ? `${base} border-yellow-400 bg-yellow-50`
-        : `${base} border-blue-400 bg-blue-50`;
-    }
-    return status === "assigned"
-      ? `${base} border-yellow-200 bg-yellow-25`
-      : `${base} border-blue-200 bg-blue-25`;
-  };
+  const base = "min-h-[400px] p-6 rounded-lg border-2 border-dashed transition-colors duration-200";
+  const style = isOver
+    ? status === "assigned"
+      ? "border-yellow-400 bg-yellow-50"
+      : "border-blue-400 bg-blue-50"
+    : status === "assigned"
+    ? "border-yellow-200 bg-yellow-50"
+    : "border-blue-200 bg-blue-50";
 
-  const dropRef = useRef<HTMLDivElement>(null)
-  drop(dropRef)
+  const ref = useRef<HTMLDivElement>(null);
+  drop(ref);
 
   return (
     <div className="space-y-4">
@@ -183,8 +137,7 @@ const DropZone = ({
           {count} cursos
         </Badge>
       </div>
-
-      <div ref={dropRef} className={getDropZoneStyle()}>
+      <div ref={ref as any} className={`${base} ${style}`}>
         <div className="space-y-3">{children}</div>
       </div>
     </div>
@@ -196,7 +149,6 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
   const [completed, setCompleted] = useState<Course[]>([]);
   const [allCourses, setAllCourses] = useState<Course[]>([]);
   const [available, setAvailable] = useState<Course[]>([]);
-  const [monthCourses, setMonthCourses] = useState<Course[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [showMonth, setShowMonth] = useState(false);
   const [pendingAssign, setPendingAssign] = useState<string[]>([]);
@@ -208,7 +160,7 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
       try {
         const [lists, courses] = await Promise.all([
           fetchStudentCourseLists(student.id),
-          fetchCourses(student.programId || undefined),
+          fetchStudentCourses(student.id),
         ]);
         setAssigned(lists.assigned);
         setCompleted(lists.completed);
@@ -221,46 +173,45 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
 
   useEffect(() => {
     const avail = allCourses.filter(
-      (c) =>
-        !assigned.some((a) => a.id === c.id) &&
-        !completed.some((co) => co.id === c.id),
+      (c) => !assigned.some((a) => a.id === c.id) && !completed.some((co) => co.id === c.id),
     );
     setAvailable(avail);
+  }, [allCourses, assigned, completed]);
 
+  const monthCourses = useMemo(() => {
     const now = new Date();
     const start = new Date(now.getFullYear(), now.getMonth(), 1);
     const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-    setMonthCourses(
-      avail.filter((c) => {
-        const d = new Date(c.startDate);
-        return d >= start && d <= end;
-      }),
-    );
-  }, [allCourses, assigned, completed]);
+    return available.filter((c) => {
+      const d = new Date(c.startDate);
+      return d >= start && d <= end;
+    });
+  }, [available]);
 
-  const handleCourseDrop = (
-    course: Course,
-    toStatus: "assigned" | "available",
-  ) => {
-    if (toStatus === "assigned") {
-      setAssigned((prev) => [...prev, course]);
-      setAvailable((prev) => prev.filter((c) => c.id !== course.id));
-      setPendingAssign((prev) =>
-        prev.includes(String(course.id)) ? prev : [...prev, String(course.id)],
-      );
-      setPendingUnassign((prev) =>
-        prev.filter((id) => id !== String(course.id)),
-      );
-    } else {
-      setAvailable((prev) => [...prev, course]);
-      setAssigned((prev) => prev.filter((c) => c.id !== course.id));
-      setPendingUnassign((prev) =>
-        prev.includes(String(course.id)) ? prev : [...prev, String(course.id)],
-      );
-      setPendingAssign((prev) => prev.filter((id) => id !== String(course.id)));
-    }
-    setHasUnsavedChanges(true);
-  };
+  useEffect(() => {
+    setHasUnsavedChanges(pendingAssign.length > 0 || pendingUnassign.length > 0);
+  }, [pendingAssign, pendingUnassign]);
+
+  const handleCourseDrop = useCallback(
+    (course: Course, to: "assigned" | "available") => {
+      if (to === "assigned") {
+        setAssigned((prev) => [...prev, course]);
+        setAvailable((prev) => prev.filter((c) => c.id !== course.id));
+        setPendingAssign((prev) =>
+          prev.includes(String(course.id)) ? prev : [...prev, String(course.id)],
+        );
+        setPendingUnassign((prev) => prev.filter((id) => id !== String(course.id)));
+      } else {
+        setAvailable((prev) => [...prev, course]);
+        setAssigned((prev) => prev.filter((c) => c.id !== course.id));
+        setPendingUnassign((prev) =>
+          prev.includes(String(course.id)) ? prev : [...prev, String(course.id)],
+        );
+        setPendingAssign((prev) => prev.filter((id) => id !== String(course.id)));
+      }
+    },
+    [],
+  );
 
   const handleSaveChanges = async () => {
     try {
@@ -272,11 +223,13 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
       }
       setPendingAssign([]);
       setPendingUnassign([]);
-      setHasUnsavedChanges(false);
     } catch (err) {
       console.error(err);
     }
   };
+
+  const filterByName = (list: Course[]) =>
+    list.filter((c) => c.name.toLowerCase().includes(searchTerm.toLowerCase()));
 
   return (
     <div className="space-y-6">
@@ -321,11 +274,7 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
           onChange={(e) => setSearchTerm(e.target.value)}
           className="max-w-xs mb-4"
         />
-        <Button
-          onClick={() => setShowMonth((v) => !v)}
-          variant="outline"
-          className="mb-4"
-        >
+        <Button onClick={() => setShowMonth((v) => !v)} variant="outline" className="mb-4">
           {showMonth ? "Ocultar mes actual" : "Ver cursos del mes"}
         </Button>
       </div>
@@ -338,19 +287,15 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
           count={assigned.length}
           icon={<Check className="h-5 w-5 mr-2" />}
         >
-          {assigned.filter((c) =>
-            c.name.toLowerCase().includes(searchTerm.toLowerCase()),
-          ).length === 0 ? (
+          {filterByName(assigned).length === 0 ? (
             <div className="text-center py-12">
               <BookOpen className="h-12 w-12 text-gray-300 mx-auto mb-4" />
               <p className="text-gray-500">Arrastra cursos aquí para asignar</p>
             </div>
           ) : (
-            assigned
-              .filter((c) => c.name.toLowerCase().includes(searchTerm.toLowerCase()))
-              .map((course) => (
-                <DraggableCourse key={course.id} course={course} status="assigned" />
-              ))
+            filterByName(assigned).map((course) => (
+              <CourseCard key={course.id} course={course} status="assigned" />
+            ))
           )}
         </DropZone>
 
@@ -362,19 +307,15 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
             count={monthCourses.length}
             icon={<Calendar className="h-5 w-5 mr-2" />}
           >
-            {monthCourses.filter((c) =>
-              c.name.toLowerCase().includes(searchTerm.toLowerCase()),
-            ).length === 0 ? (
+            {filterByName(monthCourses).length === 0 ? (
               <div className="text-center py-12">
                 <Calendar className="h-12 w-12 text-gray-300 mx-auto mb-4" />
                 <p className="text-gray-500">No hay cursos este mes</p>
               </div>
             ) : (
-              monthCourses
-                .filter((c) => c.name.toLowerCase().includes(searchTerm.toLowerCase()))
-                .map((course) => (
-                  <DraggableCourse key={course.id} course={course} status="available" />
-                ))
+              filterByName(monthCourses).map((course) => (
+                <CourseCard key={course.id} course={course} status="available" />
+              ))
             )}
           </DropZone>
         )}
@@ -386,21 +327,15 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
           count={available.length}
           icon={<X className="h-5 w-5 mr-2" />}
         >
-          {available.filter((c) =>
-            c.name.toLowerCase().includes(searchTerm.toLowerCase()),
-          ).length === 0 ? (
+          {filterByName(available).length === 0 ? (
             <div className="text-center py-12">
               <Check className="h-12 w-12 text-green-300 mx-auto mb-4" />
-              <p className="text-gray-500">
-                Todos los cursos están asignados o completados
-              </p>
+              <p className="text-gray-500">Todos los cursos están asignados o completados</p>
             </div>
           ) : (
-            available
-              .filter((c) => c.name.toLowerCase().includes(searchTerm.toLowerCase()))
-              .map((course) => (
-                <DraggableCourse key={course.id} course={course} status="available" />
-              ))
+            filterByName(available).map((course) => (
+              <CourseCard key={course.id} course={course} status="available" />
+            ))
           )}
         </DropZone>
 
@@ -414,27 +349,23 @@ export function StudentAssignmentView({ student }: StudentAssignmentViewProps) {
               {completed.length} cursos
             </Badge>
           </div>
-
-          <div className="min-h-[400px] p-6 rounded-lg border-2 border-solid border-green-200 bg-green-25">
+          <div className="min-h-[400px] p-6 rounded-lg border-2 border-solid border-green-200 bg-green-50">
             <div className="space-y-3">
-              {completed.filter((c) =>
-                c.name.toLowerCase().includes(searchTerm.toLowerCase()),
-              ).length === 0 ? (
+              {filterByName(completed).length === 0 ? (
                 <div className="text-center py-12">
                   <Award className="h-12 w-12 text-gray-300 mx-auto mb-4" />
                   <p className="text-gray-500">No hay cursos completados</p>
                 </div>
               ) : (
-                completed
-                  .filter((c) => c.name.toLowerCase().includes(searchTerm.toLowerCase()))
-                  .map((course) => (
-                    <DraggableCourse key={course.id} course={course} status="completed" />
-                  ))
+                filterByName(completed).map((course) => (
+                  <CourseCard key={course.id} course={course} status="completed" />
+                ))
               )}
             </div>
           </div>
         </div>
       </div>
+
       {hasUnsavedChanges && (
         <div className="flex justify-end mt-4">
           <Button onClick={handleSaveChanges}>Guardar Cambios</Button>

--- a/services/students.ts
+++ b/services/students.ts
@@ -76,7 +76,7 @@ export const fetchStudentCourseLists = async (
 ): Promise<{ assigned: Course[]; completed: Course[] }> => {
   let res
   try {
-    res = await api.get(`/estudiante-programa/${studentId}/with-courses`)
+    res = await api.get(`/prospectos/${studentId}`)
   } catch (err: any) {
     if (err.response?.status === 404) {
       return { assigned: [], completed: [] }
@@ -102,9 +102,13 @@ export const fetchStudentCourseLists = async (
     programas: c.programas ?? [],
   })
 
+  const assigned = Array.isArray(data.courses) ? data.courses.map(mapCourse) : []
+
   return {
-    assigned: Array.isArray(data.assigned) ? data.assigned.map(mapCourse) : [],
-    completed: Array.isArray(data.completed) ? data.completed.map(mapCourse) : [],
+    assigned,
+    completed: Array.isArray(data.completed_courses)
+      ? data.completed_courses.map(mapCourse)
+      : [],
   }
 }
 


### PR DESCRIPTION
## Summary
- update `fetchStudentCourseLists` to use `/prospectos/{id}` endpoint
- use `fetchStudentCourses` to load available courses per student

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862faf1ac988328bb1f9cc157c2eb1c