### PR TITLE
Implement ranking page with enrolled filter

### DIFF
--- a/app/academico/estatus-alumno/page.tsx
+++ b/app/academico/estatus-alumno/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Search, Download, BookOpen, DollarSign, CheckCircle, XCircle, AlertTriangle, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -10,6 +10,8 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Progress } from "@/components/ui/progress"
 import { toast } from "@/hooks/use-toast"
+import { fetchEnrolledStudents, fetchStudentCourseLists } from "@/services/students"
+import type { Course as ServiceCourse } from "@/services/courses"
 
 // Tipos
 interface Student {
@@ -249,11 +251,75 @@ const mockPayments: Payment[] = [
 ]
 
 export default function EstatusAcademico() {
-  const [students] = useState<Student[]>(mockStudents)
-  const [courses] = useState<Course[]>(mockCourses)
+  const [students, setStudents] = useState<Student[]>([])
+  const [courses, setCourses] = useState<Course[]>([])
   const [payments] = useState<Payment[]>(mockPayments)
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedStudent, setSelectedStudent] = useState<Student | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const data = await fetchEnrolledStudents()
+        const mapped: Student[] = data.map((s) => ({
+          id: s.id,
+          name: s.name,
+          program: s.program,
+          semester: 0,
+          enrollmentDate: new Date().toISOString(),
+          status: "active",
+          academicInfo: {
+            coursesApproved: 0,
+            coursesFailed: 0,
+            coursesInProgress: 0,
+            totalCourses: 0,
+            credits: { completed: 0, total: 0 },
+            gpa: 0,
+          },
+          financialInfo: {
+            enrollmentFee: 0,
+            monthlyFee: 0,
+            pendingPayments: 0,
+            totalDebt: 0,
+            lastPaymentDate: null,
+            nextPaymentDate: null,
+            paymentStatus: "up_to_date",
+          },
+        }))
+        setStudents(mapped)
+      } catch (err) {
+        console.error(err)
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    if (!selectedStudent) return
+    ;(async () => {
+      try {
+        const lists = await fetchStudentCourseLists(selectedStudent.id)
+        const mapCourse = (c: ServiceCourse): Course => ({
+          id: String(c.id),
+          studentId: selectedStudent.id,
+          name: c.name,
+          code: c.code,
+          credits: c.credits,
+          period: "",
+          status:
+            c.status === "approved"
+              ? "approved"
+              : c.status === "draft"
+                ? "pending"
+                : "in_progress",
+          grade: null,
+          professor: c.facilitator?.name ?? "",
+        })
+        setCourses([...lists.assigned, ...lists.completed].map(mapCourse))
+      } catch (err) {
+        console.error(err)
+      }
+    })()
+  }, [selectedStudent])
 
   // Filtrar estudiantes
   const filteredStudents = students.filter(
@@ -263,7 +329,7 @@ export default function EstatusAcademico() {
   )
 
   // Obtener cursos del estudiante seleccionado
-  const studentCourses = selectedStudent ? courses.filter((course) => course.studentId === selectedStudent.id) : []
+  const studentCourses = selectedStudent ? courses : []
 
   // Obtener pagos del estudiante seleccionado
   const studentPayments = selectedStudent ? payments.filter((payment) => payment.studentId === selectedStudent.id) : []

--- a/app/academico/ranking/page.tsx
+++ b/app/academico/ranking/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState } from "react"
-import { Search, Download, Filter, Trophy, Medal, Award, ArrowUp, ArrowDown, Minus, BookOpen } from "lucide-react"
+import { useState, useEffect } from "react"
+import { Search, Download, Filter, Trophy, Medal, Award, ArrowUp, ArrowDown, Minus, BookOpen, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -11,240 +11,75 @@ import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { toast } from "@/hooks/use-toast"
+import { useDebounce } from "@/hooks/use-debounce"
+import {
+  fetchRankingStudents,
+  fetchRankingCourses,
+  downloadRankingReport,
+  type RankingStudent,
+  type CoursePerformance,
+} from "@/services/ranking"
 
 // Tipos
-interface Student {
-  id: string
-  name: string
-  program: string
-  semester: number
-  gpa: number
-  credits: number
-  totalCredits: number
-  coursesCompleted: number
-  totalCourses: number
-  ranking: number
-  previousRanking: number | null
-  badges: string[]
-}
-
-interface Course {
-  id: string
-  name: string
-  code: string
-  period: string
-  students: number
-  averageGrade: number
-  passingRate: number
-  topStudent: {
-    id: string
-    name: string
-    grade: number
-  }
-}
-
-// Datos de ejemplo
-const mockStudents: Student[] = [
-  {
-    id: "1",
-    name: "María González",
-    program: "Ingeniería en Sistemas Computacionales",
-    semester: 4,
-    gpa: 9.8,
-    credits: 72,
-    totalCredits: 180,
-    coursesCompleted: 18,
-    totalCourses: 45,
-    ranking: 1,
-    previousRanking: 2,
-    badges: ["Excelencia Académica", "Mejor Promedio"],
-  },
-  {
-    id: "2",
-    name: "Juan Pérez",
-    program: "Licenciatura en Administración de Empresas",
-    semester: 3,
-    gpa: 9.5,
-    credits: 45,
-    totalCredits: 120,
-    coursesCompleted: 12,
-    totalCourses: 36,
-    ranking: 2,
-    previousRanking: 1,
-    badges: ["Excelencia Académica"],
-  },
-  {
-    id: "3",
-    name: "Ana López",
-    program: "Licenciatura en Psicología",
-    semester: 5,
-    gpa: 9.3,
-    credits: 90,
-    totalCredits: 150,
-    coursesCompleted: 22,
-    totalCourses: 38,
-    ranking: 3,
-    previousRanking: 5,
-    badges: ["Mejor Promedio en Semestre"],
-  },
-  {
-    id: "4",
-    name: "Carlos Rodríguez",
-    program: "Maestría en Educación",
-    semester: 2,
-    gpa: 9.1,
-    credits: 24,
-    totalCredits: 60,
-    coursesCompleted: 6,
-    totalCourses: 15,
-    ranking: 4,
-    previousRanking: 3,
-    badges: [],
-  },
-  {
-    id: "5",
-    name: "Pedro Sánchez",
-    program: "Ingeniería en Sistemas Computacionales",
-    semester: 6,
-    gpa: 8.9,
-    credits: 108,
-    totalCredits: 180,
-    coursesCompleted: 27,
-    totalCourses: 45,
-    ranking: 5,
-    previousRanking: 4,
-    badges: [],
-  },
-  {
-    id: "6",
-    name: "Laura Martínez",
-    program: "Licenciatura en Administración de Empresas",
-    semester: 7,
-    gpa: 8.7,
-    credits: 105,
-    totalCredits: 120,
-    coursesCompleted: 30,
-    totalCourses: 36,
-    ranking: 6,
-    previousRanking: 6,
-    badges: [],
-  },
-  {
-    id: "7",
-    name: "Roberto Díaz",
-    program: "Doctorado en Ciencias",
-    semester: 3,
-    gpa: 8.5,
-    credits: 45,
-    totalCredits: 90,
-    coursesCompleted: 10,
-    totalCourses: 20,
-    ranking: 7,
-    previousRanking: 8,
-    badges: [],
-  },
-  {
-    id: "8",
-    name: "Sofía Hernández",
-    program: "Maestría en Administración de Negocios",
-    semester: 4,
-    gpa: 8.3,
-    credits: 48,
-    totalCredits: 60,
-    coursesCompleted: 12,
-    totalCourses: 15,
-    ranking: 8,
-    previousRanking: 7,
-    badges: [],
-  },
-]
-
-const mockCourses: Course[] = [
-  {
-    id: "c1",
-    name: "Introducción a la Programación",
-    code: "CS101",
-    period: "2023-1",
-    students: 30,
-    averageGrade: 8.2,
-    passingRate: 0.85,
-    topStudent: {
-      id: "1",
-      name: "María González",
-      grade: 10.0,
-    },
-  },
-  {
-    id: "c2",
-    name: "Estadística Aplicada",
-    code: "STAT202",
-    period: "2023-1",
-    students: 25,
-    averageGrade: 7.8,
-    passingRate: 0.76,
-    topStudent: {
-      id: "3",
-      name: "Ana López",
-      grade: 9.8,
-    },
-  },
-  {
-    id: "c3",
-    name: "Metodología de la Investigación",
-    code: "RES301",
-    period: "2023-1",
-    students: 28,
-    averageGrade: 8.5,
-    passingRate: 0.89,
-    topStudent: {
-      id: "4",
-      name: "Carlos Rodríguez",
-      grade: 9.7,
-    },
-  },
-  {
-    id: "c4",
-    name: "Fundamentos de Administración",
-    code: "ADM101",
-    period: "2023-1",
-    students: 35,
-    averageGrade: 8.0,
-    passingRate: 0.83,
-    topStudent: {
-      id: "2",
-      name: "Juan Pérez",
-      grade: 9.9,
-    },
-  },
-  {
-    id: "c5",
-    name: "Programación Orientada a Objetos",
-    code: "CS201",
-    period: "2023-1",
-    students: 22,
-    averageGrade: 7.9,
-    passingRate: 0.77,
-    topStudent: {
-      id: "1",
-      name: "María González",
-      grade: 9.8,
-    },
-  },
-]
+// Initial data is fetched from the API
 
 export default function RankingAcademico() {
-  const [students] = useState<Student[]>(mockStudents)
-  const [courses] = useState<Course[]>(mockCourses)
+  const [students, setStudents] = useState<RankingStudent[]>([])
+  const [courses, setCourses] = useState<CoursePerformance[]>([])
+  const [totalStudents, setTotalStudents] = useState(0)
   const [searchTerm, setSearchTerm] = useState("")
   const [programFilter, setProgramFilter] = useState<string>("all")
   const [semesterFilter, setSemesterFilter] = useState<string>("all")
   const [sortBy, setSortBy] = useState<string>("ranking")
+  const [loadingStudents, setLoadingStudents] = useState(false)
+  const [loadingCourses, setLoadingCourses] = useState(false)
+  const [downloading, setDownloading] = useState(false)
+  const debouncedSearch = useDebounce(searchTerm, 300)
+
+  // Fetch students whenever filters change
+  useEffect(() => {
+    const getStudents = async () => {
+      setLoadingStudents(true)
+      try {
+        const { data, total } = await fetchRankingStudents({
+          search: debouncedSearch || undefined,
+          program: programFilter !== 'all' ? programFilter : undefined,
+          semester: semesterFilter !== 'all' ? Number(semesterFilter) : undefined,
+          sortBy,
+          onlyEnrolled: true,
+        })
+        setStudents(data)
+        setTotalStudents(total)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoadingStudents(false)
+      }
+    }
+    getStudents()
+  }, [debouncedSearch, programFilter, semesterFilter, sortBy])
+
+  // Fetch courses on mount
+  useEffect(() => {
+    const getCourses = async () => {
+      setLoadingCourses(true)
+      try {
+        const { data } = await fetchRankingCourses({})
+        setCourses(data)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoadingCourses(false)
+      }
+    }
+    getCourses()
+  }, [])
 
   // Obtener programas únicos para el filtro
-  const uniquePrograms = Array.from(new Set(students.map(s => s.program)))
-  
+  const uniquePrograms = Array.from(new Set(students.map((s) => s.program)))
+
   // Obtener semestres únicos para el filtro
-  const uniqueSemesters = Array.from(new Set(students.map(s => s.semester))).sort((a, b) => a - b)
+  const uniqueSemesters = Array.from(new Set(students.map((s) => s.semester))).sort((a, b) => a - b)
 
   // Filtrar estudiantes
   const filteredStudents = students.filter(student => {
@@ -274,11 +109,33 @@ export default function RankingAcademico() {
   })
 
   // Descargar reporte
-  const handleDownloadReport = () => {
-    toast({
-      title: "Reporte descargado",
-      description: "El reporte de ranking académico ha sido descargado correctamente."
-    })
+  const handleDownloadReport = async () => {
+    setDownloading(true)
+    try {
+      const blob = await downloadRankingReport({
+        search: debouncedSearch || undefined,
+        program: programFilter !== 'all' ? programFilter : undefined,
+        semester: semesterFilter !== 'all' ? Number(semesterFilter) : undefined,
+        sortBy,
+      })
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = 'ranking.pdf'
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      toast({ title: 'Reporte descargado' })
+    } catch (err) {
+      console.error(err)
+      toast({
+        title: 'Error',
+        description: 'No se pudo descargar el reporte',
+        variant: 'destructive',
+      })
+    } finally {
+      setDownloading(false)
+    }
   }
 
   // Renderizar indicador de cambio en el ranking
@@ -319,8 +176,13 @@ export default function RankingAcademico() {
     <div className="container mx-auto py-6">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold">Ranking y Rendimiento Académico</h1>
-        <Button onClick={handleDownloadReport}>
-          <Download className="mr-2 h-4 w-4" /> Descargar Reporte
+        <Button onClick={handleDownloadReport} disabled={downloading}>
+          {downloading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="mr-2 h-4 w-4" />
+          )}
+          {downloading ? 'Descargando...' : 'Descargar Reporte'}
         </Button>
       </div>
 
@@ -338,6 +200,11 @@ export default function RankingAcademico() {
         
         <TabsContent value="students">
           {/* Top 3 estudiantes */}
+          {loadingStudents ? (
+            <div className="flex justify-center py-6">
+              <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+            </div>
+          ) : (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
             {students.slice(0, 3).map((student, index) => (
               <Card
@@ -397,6 +264,7 @@ export default function RankingAcademico() {
               </Card>
             ))}
           </div>
+          )}
 
           {/* Filtros */}
           <Card className="mb-6">
@@ -479,7 +347,13 @@ export default function RankingAcademico() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {sortedStudents.length === 0 ? (
+                    {loadingStudents ? (
+                      <TableRow>
+                        <TableCell colSpan={6} className="text-center py-4">
+                          <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+                        </TableCell>
+                      </TableRow>
+                    ) : sortedStudents.length === 0 ? (
                       <TableRow>
                         <TableCell colSpan={6} className="text-center py-4 text-gray-500">
                           No se encontraron estudiantes con los filtros seleccionados
@@ -585,19 +459,43 @@ export default function RankingAcademico() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {courses.map((course) => (
-                      <TableRow key={course.id}>
-                        <TableCell>{course.name}</TableCell>
-                        <TableCell>{course.code}</TableCell>
-                        <TableCell>{course.period}</TableCell>
-                        <TableCell>{course.students}</TableCell>
-                        <TableCell>{course.averageGrade.toFixed(1)}</TableCell>
-                        <TableCell>{Math.round(course.passingRate * 100)}%</TableCell>
-                        <TableCell>
-                          {course.topStudent.name} ({course.topStudent.grade.toFixed(1)})
+                    {loadingCourses ? (
+                      <TableRow>
+                        <TableCell colSpan={7} className="text-center py-4">
+                          <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
                         </TableCell>
                       </TableRow>
-                    ))}
+                    ) : courses.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={7} className="text-center py-4 text-gray-500">
+                          No hay información disponible
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      courses.map((course) => (
+                        <TableRow key={course.id}>
+                          <TableCell>{course.name}</TableCell>
+                          <TableCell>{course.code}</TableCell>
+                          <TableCell>{course.period}</TableCell>
+                          <TableCell>{course.students}</TableCell>
+                          <TableCell>
+                            {course.averageGrade !== undefined && course.averageGrade !== null
+                              ? course.averageGrade.toFixed(1)
+                              : "-"}
+                          </TableCell>
+                          <TableCell>
+                            {course.passingRate !== undefined && course.passingRate !== null
+                              ? `${Math.round(course.passingRate * 100)}%`
+                              : "-"}
+                          </TableCell>
+                          <TableCell>
+                            {course.topStudent && course.topStudent.name
+                              ? `${course.topStudent.name} (${course.topStudent.grade?.toFixed(1) ?? "-"})`
+                              : "-"}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
                   </TableBody>
                 </Table>
               </div>

--- a/services/ranking.ts
+++ b/services/ranking.ts
@@ -1,0 +1,71 @@
+import api from './api'
+
+// Types for ranking students and course performance
+export interface RankingStudent {
+  id: string
+  name: string
+  program: string
+  semester: number
+  gpa: number
+  credits: number
+  totalCredits: number
+  coursesCompleted: number
+  totalCourses: number
+  ranking: number
+  previousRanking: number | null
+  badges: string[]
+}
+
+export interface CoursePerformance {
+  id: string
+  name: string
+  code: string
+  period: string
+  students: number
+  averageGrade?: number | null
+  passingRate?: number | null
+  topStudent?: {
+    id?: string
+    name?: string
+    grade?: number | null
+  }
+}
+
+export interface RankingParams {
+  page?: number
+  perPage?: number
+  search?: string
+  program?: string
+  semester?: number
+  sortBy?: string
+}
+
+// Fetch ranking of students from backend
+// Requires an endpoint like GET /ranking/students
+export const fetchRankingStudents = async (
+  params: RankingParams & { onlyEnrolled?: boolean } = {},
+) => {
+  const res = await api.get('/ranking/students', {
+    params: {
+      status: params.onlyEnrolled ? 'Inscrito' : undefined,
+      ...params,
+    },
+  })
+  const data = Array.isArray(res.data.data) ? res.data : { data: res.data, total: res.data.length }
+  return { data: data.data as RankingStudent[], total: data.total as number }
+}
+
+// Fetch course performance ranking
+// Requires an endpoint like GET /ranking/courses
+export const fetchRankingCourses = async (params: RankingParams) => {
+  const res = await api.get('/ranking/courses', { params })
+  const data = Array.isArray(res.data.data) ? res.data : { data: res.data, total: res.data.length }
+  return { data: data.data as CoursePerformance[], total: data.total as number }
+}
+
+// Download ranking report as file
+// Requires an endpoint like GET /ranking/report that returns a blob
+export const downloadRankingReport = async (params: RankingParams) => {
+  const res = await api.get('/ranking/report', { params, responseType: 'blob' })
+  return res.data as Blob
+}


### PR DESCRIPTION
## Summary
- filter ranking results to only include enrolled students

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b72c4ae88328a5298eb8362dc8a4