### PR TITLE
Add loading indicator for student list

### DIFF
--- a/app/academico/asignacion/loading.tsx
+++ b/app/academico/asignacion/loading.tsx
@@ -1,4 +1,11 @@
 export default function Loading() {
-  return null
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className="flex flex-col items-center gap-2">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+        <p className="text-sm text-muted-foreground">Cargando estudiantes...</p>
+      </div>
+    </div>
+  )
 }
 

--- a/app/academico/asignacion/page.tsx
+++ b/app/academico/asignacion/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useMemo } from "react"
-import { Search } from "lucide-react"
+import { Search, Loader2 } from "lucide-react"
 import {
   Pagination,
   PaginationContent,
@@ -297,7 +297,12 @@ export default function AsignacionPage() {
             </Select>
           </div>
 
-          {loading && <p>Cargando...</p>}
+          {loading && (
+            <div className="flex items-center justify-center py-4">
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <span>Cargando estudiantes...</span>
+            </div>
+          )}
           {error && <p className="text-red-500">{error}</p>}
 
           <div className="overflow-x-auto">

--- a/app/academico/programacion/loading.tsx
+++ b/app/academico/programacion/loading.tsx
@@ -1,4 +1,11 @@
 export default function Loading() {
-  return null
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className="flex flex-col items-center gap-2">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+        <p className="text-sm text-muted-foreground">Cargando cursos...</p>
+      </div>
+    </div>
+  )
 }
 

--- a/app/academico/programacion/page.tsx
+++ b/app/academico/programacion/page.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 
 import { useState, useEffect } from "react"
-import { Search, Plus, Edit, Trash, Calendar, Clock, User, CheckCircle, ArrowRight, ExternalLink } from "lucide-react"
+import { Search, Plus, Edit, Trash, Calendar, Clock, User, CheckCircle, ArrowRight, ExternalLink, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
@@ -65,10 +65,25 @@ export default function ProgramacionCursos() {
   const [selectedCourse, setSelectedCourse] = useState<Course | null>(null)
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [isSyncingToMoodle, setIsSyncingToMoodle] = useState(false)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetchCourses().then(setCourses).catch(console.error)
-    fetchFacilitators().then(setFacilitators).catch(console.error)
+    const loadData = async () => {
+      setLoading(true)
+      try {
+        const [courseData, facilitatorData] = await Promise.all([
+          fetchCourses(),
+          fetchFacilitators(),
+        ])
+        setCourses(courseData)
+        setFacilitators(facilitatorData)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadData()
   }, [])
 
 
@@ -296,7 +311,8 @@ export default function ProgramacionCursos() {
                     </SelectContent>
                   </Select>
                 </div>
-              </div>
+                </div>
+              )}
             </CardContent>
           </Card>
 
@@ -306,8 +322,14 @@ export default function ProgramacionCursos() {
               <CardTitle>Cursos Programados</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="rounded-md border">
-                <Table>
+              {loading ? (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <span>Cargando cursos...</span>
+                </div>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
                   <TableHeader>
                     <TableRow>
                       <TableHead>Curso</TableHead>
@@ -413,6 +435,7 @@ export default function ProgramacionCursos() {
                   </TableBody>
                 </Table>
               </div>
+              )}
             </CardContent>
           </Card>
 

--- a/app/academico/usuarios/loading.tsx
+++ b/app/academico/usuarios/loading.tsx
@@ -1,4 +1,11 @@
 export default function Loading() {
-  return null
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className="flex flex-col items-center gap-2">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+        <p className="text-sm text-muted-foreground">Cargando usuarios...</p>
+      </div>
+    </div>
+  )
 }
 

--- a/app/academico/usuarios/page.tsx
+++ b/app/academico/usuarios/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { useState, useEffect, useMemo } from "react"
-import { Search, Plus, Edit, Trash, Mail, MessageSquare, RefreshCw, Filter } from "lucide-react"
+import { Search, Plus, Edit, Trash, Mail, MessageSquare, RefreshCw, Filter, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -123,6 +123,7 @@ export default function GestionUsuarios() {
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [pageSize, setPageSize] = useState<string>("5")
   const [currentPage, setCurrentPage] = useState<number>(1)
+  const [loading, setLoading] = useState(false)
 
   // Formulario de estudiante
   const [formData, setFormData] = useState<Omit<Student, "id" | "status" | "username" | "institutionalEmail" | "password">>({
@@ -138,6 +139,7 @@ export default function GestionUsuarios() {
   // Cargar estudiantes desde la API
 useEffect(() => {
   async function fetchStudents() {
+    setLoading(true)
     try {
       const token = localStorage.getItem("token") || "";
       const statuses = ["Pendiente Aprobacion", "aprobada"];
@@ -191,12 +193,13 @@ useEffect(() => {
       setFetchError(
         "No se pudieron cargar los estudiantes. Ver consola para más detalles."
       );
+    } finally {
+      setLoading(false)
     }
   }
-  
-  console.log('[DEBUG] Iniciando carga de estudiantes...');
-  fetchStudents();
-}, []);
+
+  fetchStudents()
+}, [])
 
   // Filtrar estudiantes
   const filteredStudents = useMemo(() => {
@@ -506,9 +509,16 @@ useEffect(() => {
             <CardTitle>Estudiantes</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="rounded-md border">
-              <Table>
-                <TableHeader>
+            {loading ? (
+              <div className="flex items-center justify-center py-4">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <span>Cargando estudiantes...</span>
+              </div>
+            ) : (
+              <>
+                <div className="rounded-md border">
+                  <Table>
+                  <TableHeader>
                   <TableRow>
                     <TableHead>Nombre</TableHead>
                     <TableHead>Programa</TableHead>
@@ -573,18 +583,18 @@ useEffect(() => {
                     ))
                   )}
                 </TableBody>
-              </Table>
-            </div>
+                  </Table>
+                </div>
 
-            {pageSize !== "all" && (
-              <div className="flex items-center justify-end gap-2 p-2">
-                <Select
-                  value={pageSize}
-                  onValueChange={(v) => {
-                    setPageSize(v)
-                    setCurrentPage(1)
-                  }}
-                >
+                {pageSize !== "all" && (
+                  <div className="flex items-center justify-end gap-2 p-2">
+                  <Select
+                    value={pageSize}
+                    onValueChange={(v) => {
+                      setPageSize(v)
+                      setCurrentPage(1)
+                    }}
+                  >
                   <SelectTrigger className="w-[120px]">
                     <SelectValue placeholder="Paginación" />
                   </SelectTrigger>
@@ -607,8 +617,10 @@ useEffect(() => {
                   disabled={currentPage === totalPages || totalPages === 0}
                 >
                   Siguiente
-                </Button>
-              </div>
+                    </Button>
+                  </div>
+                )}
+              </>
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- show spinner during page load for `academico/asignacion`
- display spinner while fetching students
- add more loaders across admin pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e72cba308328a9d8947dd491201d