### PR TITLE
Fix invalid email when creating credentials

### DIFF
--- a/app/academico/ranking/page.tsx
+++ b/app/academico/ranking/page.tsx
@@ -41,17 +41,16 @@ export default function RankingAcademico() {
     const getStudents = async () => {
       setLoadingStudents(true)
       try {
-        const { data, total } = await fetchRankingStudents({
+        const { data } = await fetchRankingStudents({
           search: debouncedSearch || undefined,
           program: programFilter !== 'all' ? programFilter : undefined,
           semester: semesterFilter !== 'all' ? Number(semesterFilter) : undefined,
           sortBy,
-
-          onlyEnrolled: true,
-
         })
-        setStudents(data)
-        setTotalStudents(total)
+
+        const withCourses = data.filter((s) => s.totalCourses > 0)
+        setStudents(withCourses)
+        setTotalStudents(withCourses.length)
       } catch (err) {
         console.error(err)
       } finally {
@@ -474,8 +473,8 @@ export default function RankingAcademico() {
                         </TableCell>
                       </TableRow>
                     ) : (
-                      courses.map((course) => (
-                        <TableRow key={course.id}>
+                      courses.map((course, idx) => (
+                        <TableRow key={course.id ?? idx}>
                           <TableCell>{course.name}</TableCell>
                           <TableCell>{course.code}</TableCell>
                           <TableCell>{course.period}</TableCell>

--- a/app/academico/usuarios/page.tsx
+++ b/app/academico/usuarios/page.tsx
@@ -378,9 +378,10 @@ useEffect(() => {
 
     try {
       // Generar username base
-      const base = `${selectedStudent.name.toLowerCase()}.${selectedStudent.lastName.toLowerCase()}`
+      const base = `${selectedStudent.name.toLowerCase().trim()}.${selectedStudent.lastName.toLowerCase().trim()}`
         .normalize("NFD")
         .replace(/[\u0300-\u036f]/g, "")
+        .replace(/\s+/g, "")
       let username = base
       let institutionalEmail = `${username}@americanschool.edu.gt`
       let suffix = 1

--- a/components/admin/Modals/EditProspectModal.tsx
+++ b/components/admin/Modals/EditProspectModal.tsx
@@ -8,6 +8,7 @@ import {
     DialogFooter,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { Loader2 } from "lucide-react"
 import { API_BASE_URL } from "@/utils/apiConfig"
 import {
     Select,
@@ -45,6 +46,7 @@ export default function EditProspectModal({
 }: EditProspectModalProps) {
     const [selectedAsesor, setSelectedAsesor] = useState<string>("")
     const [search, setSearch] = useState<string>("")
+    const [isSaving, setIsSaving] = useState(false)
 
     const visibleAsesores = useMemo(() => {
         const term = search.toLowerCase()
@@ -69,6 +71,8 @@ export default function EditProspectModal({
 
     const handleGuardar = async () => {
         if (!selectedAsesor) return
+
+        setIsSaving(true)
 
         try {
             if (bulkIds && bulkIds.length > 0) {
@@ -117,6 +121,8 @@ export default function EditProspectModal({
         } catch (err) {
             console.error("Error reasignando prospectos:", err)
             alert("No se pudo reasignar. Revisa la consola para más detalles.")
+        } finally {
+            setIsSaving(false)
         }
     }
 
@@ -182,8 +188,15 @@ export default function EditProspectModal({
                     <Button variant="outline" onClick={onClose}>
                         Cancelar
                     </Button>
-                    <Button onClick={handleGuardar} disabled={!selectedAsesor}>
-                        Guardar
+                    <Button onClick={handleGuardar} disabled={!selectedAsesor || isSaving}>
+                        {isSaving ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Guardando...
+                            </>
+                        ) : (
+                            'Guardar'
+                        )}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/components/inscripcion/gestion-fichas.tsx
+++ b/components/inscripcion/gestion-fichas.tsx
@@ -29,7 +29,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select"
-import { Eye, CheckCircle, XCircle, Calendar } from "lucide-react"
+import { Eye, CheckCircle, XCircle, Calendar, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { FichaEstudiante } from "@/components/inscripcion/types"
@@ -57,6 +57,7 @@ export function GestionFichas() {
   const [selectedFicha, setSelectedFicha] = useState<FichaEstudiante | null>(null)
   const [activeTab, setActiveTab] = useState<"fichas" | "documentos">("fichas")
   const [isDetalleModalOpen, setDetalleModalOpen] = useState(false)
+  const [processingId, setProcessingId] = useState<number | null>(null)
 
   useEffect(() => {
     async function fetchFichas() {
@@ -114,6 +115,7 @@ export function GestionFichas() {
   }
 
   const handleApprove = async (id: number) => {
+    setProcessingId(id)
     try {
       const token = localStorage.getItem("token")
       const res = await fetch(`${API_URL}/prospectos/${id}/status`, {
@@ -139,10 +141,13 @@ export function GestionFichas() {
     } catch (err) {
       console.error("Error al aprobar ficha", err)
       Swal.fire("Oops...", "No se pudo aprobar la ficha", "error")
+    } finally {
+      setProcessingId(null)
     }
   }
 
   const handleReject = async (id: number) => {
+    setProcessingId(id)
     try {
       const token = localStorage.getItem("token")
       const res = await fetch(`${API_URL}/fichas/${id}/reject`, {
@@ -158,6 +163,8 @@ export function GestionFichas() {
     } catch (err) {
       console.error("Error al rechazar ficha", err)
       Swal.fire("Error", "No se pudo rechazar la ficha", "error")
+    } finally {
+      setProcessingId(null)
     }
   }
 
@@ -293,11 +300,29 @@ export function GestionFichas() {
                       <Button variant="ghost" size="icon" onClick={() => handleViewDetalle(f)}>
                         <Eye className="h-4 w-4" />
                       </Button>
-                      <Button variant="ghost" size="icon" onClick={() => handleApprove(f.id)} disabled={f.estado === "aprobada"}>
-                        <CheckCircle className={`h-4 w-4 ${f.estado === "aprobada" ? "text-gray-400" : "text-green-500"}`} />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleApprove(f.id)}
+                        disabled={f.estado === "aprobada" || processingId === f.id}
+                      >
+                        {processingId === f.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <CheckCircle className={`h-4 w-4 ${f.estado === "aprobada" ? "text-gray-400" : "text-green-500"}`} />
+                        )}
                       </Button>
-                      <Button variant="ghost" size="icon" onClick={() => handleReject(f.id)}>
-                        <XCircle className="h-4 w-4 text-red-500" />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleReject(f.id)}
+                        disabled={processingId === f.id}
+                      >
+                        {processingId === f.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <XCircle className="h-4 w-4 text-red-500" />
+                        )}
                       </Button>
                     </div>
                   </TableCell>

--- a/services/ranking.ts
+++ b/services/ranking.ts
@@ -45,7 +45,7 @@ export interface RankingParams {
 // Requires an endpoint like GET /ranking/students
 
 export const fetchRankingStudents = async (
-  params: RankingParams & { onlyEnrolled?: boolean } = {},
+  params: RankingParams & { onlyEnrolled?: boolean } = { onlyEnrolled: true },
 ) => {
   const res = await api.get('/ranking/students', {
     params: {


### PR DESCRIPTION
## Summary
- sanitize spaces when generating username and email
- default ranking students to enrolled only
- filter students with assigned courses
- add loading spinners to modals and ficha actions
- fix course table key warning

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f39f03108328b3f31d07bbe4e85c