### PR TITLE
Implement dynamic dashboard metrics

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import type { Metadata } from "next"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
@@ -13,6 +16,9 @@ import {
   Settings,
 } from "lucide-react"
 import Link from "next/link"
+import { fetchCourses } from "@/services/courses"
+import { fetchEnrolledStudents } from "@/services/students"
+import { fetchUsers } from "@/services/users"
 
 export const metadata: Metadata = {
   title: "Dashboard | Blue Atlas",
@@ -86,6 +92,28 @@ export default function DashboardPage() {
     },
   ]
 
+  const [totalUsers, setTotalUsers] = useState<number>(0)
+  const [activeStudents, setActiveStudents] = useState<number>(0)
+  const [activeCourses, setActiveCourses] = useState<number>(0)
+
+  useEffect(() => {
+    const loadMetrics = async () => {
+      try {
+        const [users, students, courses] = await Promise.all([
+          fetchUsers(),
+          fetchEnrolledStudents(),
+          fetchCourses(),
+        ])
+        setTotalUsers(users.length)
+        setActiveStudents(students.length)
+        setActiveCourses(courses.length)
+      } catch (err) {
+        console.error('Error fetching dashboard metrics', err)
+      }
+    }
+    loadMetrics()
+  }, [])
+
   return (
     <div className="flex-1 space-y-4 p-8 pt-6">
       <div className="flex items-center justify-between space-y-2">
@@ -107,8 +135,8 @@ export default function DashboardPage() {
                 <Users className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">1,248</div>
-                <p className="text-xs text-muted-foreground">+12% respecto al mes anterior</p>
+                <div className="text-2xl font-bold">{totalUsers}</div>
+                <p className="text-xs text-muted-foreground">Usuarios registrados</p>
               </CardContent>
             </Card>
             <Card>
@@ -117,8 +145,8 @@ export default function DashboardPage() {
                 <BookOpen className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">845</div>
-                <p className="text-xs text-muted-foreground">+5% respecto al mes anterior</p>
+                <div className="text-2xl font-bold">{activeStudents}</div>
+                <p className="text-xs text-muted-foreground">Estudiantes inscritos</p>
               </CardContent>
             </Card>
             <Card>
@@ -127,8 +155,8 @@ export default function DashboardPage() {
                 <GraduationCap className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">42</div>
-                <p className="text-xs text-muted-foreground">+2 nuevos cursos este mes</p>
+                <div className="text-2xl font-bold">{activeCourses}</div>
+                <p className="text-xs text-muted-foreground">Cursos activos</p>
               </CardContent>
             </Card>
           </div>

--- a/components/calendario-semanal.tsx
+++ b/components/calendario-semanal.tsx
@@ -1,28 +1,44 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { api } from "@/services/api"
+
+interface Cita {
+  id: number
+  datecita: string
+  descricita: string
+}
+
 export default function CalendarioSemanal() {
   const dias = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"]
 
-  const eventos = [
-    { dia: "Lunes", hora: "09:00", titulo: "Llamada con Juan Pérez", color: "bg-blue-100 border-blue-300" },
-    {
-      dia: "Martes",
-      hora: "11:00",
-      titulo: "Reunión virtual con María García",
-      color: "bg-purple-100 border-purple-300",
-      hoy: true,
-    },
-    {
-      dia: "Miércoles",
-      hora: "15:00",
-      titulo: "Seguimiento a Carlos Rodríguez",
-      color: "bg-green-100 border-green-300",
-    },
-    {
-      dia: "Viernes",
-      hora: "10:00",
-      titulo: "Presentación a nuevo prospecto",
-      color: "bg-orange-100 border-orange-300",
-    },
-  ]
+  const [citas, setCitas] = useState<Cita[]>([])
+
+  useEffect(() => {
+    const fetchCitas = async () => {
+      try {
+        const res = await api.get('/citas')
+        const data = Array.isArray(res.data) ? res.data : res.data.data || []
+        setCitas(data)
+      } catch (err) {
+        console.error('Error fetching citas', err)
+      }
+    }
+    fetchCitas()
+  }, [])
+
+  const eventos = citas.map(c => {
+    const d = new Date(c.datecita)
+    const diaIdx = d.getDay() === 0 ? 6 : d.getDay() - 1
+    return {
+      dia: dias[diaIdx],
+      hora: d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      titulo: c.descricita,
+      color: 'bg-blue-100 border-blue-300',
+    }
+  })
+
+  const hoy = dias[new Date().getDay() === 0 ? 6 : new Date().getDay() - 1]
 
   return (
     <div className="bg-white rounded-lg border shadow-sm p-4">
@@ -33,11 +49,11 @@ export default function CalendarioSemanal() {
           <div key={dia} className="border rounded-lg">
             <div
               className={`p-2 text-center font-medium text-sm border-b ${
-                dia === "Martes" ? "bg-blue-50 text-blue-600" : ""
+                dia === hoy ? 'bg-blue-50 text-blue-600' : ''
               }`}
             >
               {dia}
-              {dia === "Martes" && <div className="text-xs text-blue-600">Hoy</div>}
+              {dia === hoy && <div className="text-xs text-blue-600">Hoy</div>}
             </div>
 
             <div className="p-2 h-32">

--- a/services/users.ts
+++ b/services/users.ts
@@ -1,0 +1,13 @@
+import api from './api'
+
+export interface User {
+  id: number
+  name: string
+  email: string
+}
+
+export const fetchUsers = async (): Promise<User[]> => {
+  const res = await api.get('/users', { params: { per_page: 9999 } })
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return data as User[]
+}


### PR DESCRIPTION
## Summary
- connect dashboard cards to API counts
- load calendar events from `/citas` endpoint
- provide helper to fetch all users

## Testing
- `npx next lint` *(fails: E403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68671508072c832889775c5c062b42d7