### PR TITLE
Implement dynamic dashboard metrics

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import type { Metadata } from "next"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
@@ -13,6 +16,13 @@ import {
   Settings,
 } from "lucide-react"
 import Link from "next/link"
+import { fetchCourses } from "@/services/courses"
+import { fetchEnrolledStudents } from "@/services/students"
+import { fetchUsers, fetchCurrentUser } from "@/services/users"
+import {
+  fetchProspectos,
+  fetchProspectCountByStatus,
+} from '@/services/prospectos'
 
 export const metadata: Metadata = {
   title: "Dashboard | Blue Atlas",
@@ -86,6 +96,55 @@ export default function DashboardPage() {
     },
   ]
 
+  const [totalUsers, setTotalUsers] = useState<number>(0)
+  const [activeStudents, setActiveStudents] = useState<number>(0)
+  const [activeCourses, setActiveCourses] = useState<number>(0)
+  const [myProspects, setMyProspects] = useState<number>(0)
+  const [leadStats, setLeadStats] = useState<Record<string, number>>({})
+
+  useEffect(() => {
+    const loadMetrics = async () => {
+      try {
+        const currentUser = await fetchCurrentUser()
+        const [users, students, courses, prospects] = await Promise.all([
+          fetchUsers(),
+          fetchEnrolledStudents(),
+          fetchCourses(),
+          fetchProspectos(),
+        ])
+
+        setTotalUsers(users.length)
+        setActiveStudents(students.length)
+        setActiveCourses(courses.length)
+
+        if (currentUser) {
+          const mine =
+            currentUser.rol === 'Administrador'
+              ? prospects.length
+              : prospects.filter(
+                  p => p.created_by === currentUser.id,
+                ).length
+          setMyProspects(mine)
+
+          const statuses = [
+            'Interesado',
+            'No le interesa',
+            'En seguimiento',
+            'No volver a contactar',
+          ]
+          const counts: Record<string, number> = {}
+          for (const s of statuses) {
+            counts[s] = await fetchProspectCountByStatus(s)
+          }
+          setLeadStats(counts)
+        }
+      } catch (err) {
+        console.error('Error fetching dashboard metrics', err)
+      }
+    }
+    loadMetrics()
+  }, [])
+
   return (
     <div className="flex-1 space-y-4 p-8 pt-6">
       <div className="flex items-center justify-between space-y-2">
@@ -99,7 +158,7 @@ export default function DashboardPage() {
           <TabsTrigger value="notifications">Notificaciones</TabsTrigger>
         </TabsList>
         <TabsContent value="overview" className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             {/* Tarjetas de estadísticas */}
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -107,8 +166,8 @@ export default function DashboardPage() {
                 <Users className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">1,248</div>
-                <p className="text-xs text-muted-foreground">+12% respecto al mes anterior</p>
+                <div className="text-2xl font-bold">{totalUsers}</div>
+                <p className="text-xs text-muted-foreground">Usuarios registrados</p>
               </CardContent>
             </Card>
             <Card>
@@ -117,8 +176,8 @@ export default function DashboardPage() {
                 <BookOpen className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">845</div>
-                <p className="text-xs text-muted-foreground">+5% respecto al mes anterior</p>
+                <div className="text-2xl font-bold">{activeStudents}</div>
+                <p className="text-xs text-muted-foreground">Estudiantes inscritos</p>
               </CardContent>
             </Card>
             <Card>
@@ -127,8 +186,18 @@ export default function DashboardPage() {
                 <GraduationCap className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">42</div>
-                <p className="text-xs text-muted-foreground">+2 nuevos cursos este mes</p>
+                <div className="text-2xl font-bold">{activeCourses}</div>
+                <p className="text-xs text-muted-foreground">Cursos activos</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Mis Prospectos</CardTitle>
+                <Users className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{myProspects}</div>
+                <p className="text-xs text-muted-foreground">Prospectos asignados</p>
               </CardContent>
             </Card>
           </div>
@@ -151,6 +220,21 @@ export default function DashboardPage() {
               </Link>
             ))}
           </div>
+
+          {Object.keys(leadStats).length > 0 && (
+            <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
+              {Object.entries(leadStats).map(([label, count]) => (
+                <Card key={label}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm font-medium">{label}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="text-2xl font-bold">{count}</div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
         </TabsContent>
         <TabsContent value="analytics" className="space-y-4">
           <Card>

--- a/components/calendario-semanal.tsx
+++ b/components/calendario-semanal.tsx
@@ -1,28 +1,66 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { api } from "@/services/api"
+import { startOfWeek, endOfWeek, isWithinInterval } from 'date-fns'
+import { fetchCurrentUser, type User } from '@/services/users'
+
+interface Cita {
+  id: number
+  datecita: string
+  descricita: string
+  created_by?: number
+  user_id?: number
+}
+
 export default function CalendarioSemanal() {
   const dias = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"]
 
-  const eventos = [
-    { dia: "Lunes", hora: "09:00", titulo: "Llamada con Juan Pérez", color: "bg-blue-100 border-blue-300" },
-    {
-      dia: "Martes",
-      hora: "11:00",
-      titulo: "Reunión virtual con María García",
-      color: "bg-purple-100 border-purple-300",
-      hoy: true,
-    },
-    {
-      dia: "Miércoles",
-      hora: "15:00",
-      titulo: "Seguimiento a Carlos Rodríguez",
-      color: "bg-green-100 border-green-300",
-    },
-    {
-      dia: "Viernes",
-      hora: "10:00",
-      titulo: "Presentación a nuevo prospecto",
-      color: "bg-orange-100 border-orange-300",
-    },
-  ]
+  const [citas, setCitas] = useState<Cita[]>([])
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const fetchCitas = async () => {
+      try {
+        const currentUser = await fetchCurrentUser()
+        setUser(currentUser)
+
+        const res = await api.get('/citas')
+        let data = Array.isArray(res.data) ? res.data : res.data.data || []
+
+        const start = startOfWeek(new Date(), { weekStartsOn: 1 })
+        const end = endOfWeek(new Date(), { weekStartsOn: 1 })
+
+        data = data.filter((c: Cita) => {
+          const d = new Date(c.datecita)
+          const inWeek = isWithinInterval(d, { start, end })
+          const owned =
+            currentUser?.rol === 'Administrador' ||
+            c.created_by === currentUser?.id ||
+            c.user_id === currentUser?.id
+          return inWeek && owned
+        })
+
+        setCitas(data)
+      } catch (err) {
+        console.error('Error fetching citas', err)
+      }
+    }
+    fetchCitas()
+  }, [])
+
+  const eventos = citas.map(c => {
+    const d = new Date(c.datecita)
+    const diaIdx = d.getDay() === 0 ? 6 : d.getDay() - 1
+    return {
+      dia: dias[diaIdx],
+      hora: d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      titulo: c.descricita,
+      color: 'bg-blue-100 border-blue-300',
+    }
+  })
+
+  const hoy = dias[new Date().getDay() === 0 ? 6 : new Date().getDay() - 1]
 
   return (
     <div className="bg-white rounded-lg border shadow-sm p-4">
@@ -33,11 +71,11 @@ export default function CalendarioSemanal() {
           <div key={dia} className="border rounded-lg">
             <div
               className={`p-2 text-center font-medium text-sm border-b ${
-                dia === "Martes" ? "bg-blue-50 text-blue-600" : ""
+                dia === hoy ? 'bg-blue-50 text-blue-600' : ''
               }`}
             >
               {dia}
-              {dia === "Martes" && <div className="text-xs text-blue-600">Hoy</div>}
+              {dia === hoy && <div className="text-xs text-blue-600">Hoy</div>}
             </div>
 
             <div className="p-2 h-32">

--- a/services/prospectos.ts
+++ b/services/prospectos.ts
@@ -1,0 +1,23 @@
+import api from './api'
+
+export interface Prospecto {
+  id: number
+  status: string
+  created_by?: number
+}
+
+export const fetchProspectos = async (): Promise<Prospecto[]> => {
+  const res = await api.get('/prospectos')
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return data as Prospecto[]
+}
+
+export const fetchProspectCountByStatus = async (
+  status: string,
+): Promise<number> => {
+  const res = await api.get(`/prospectos/status/${encodeURIComponent(status)}`, {
+    params: { per_page: 9999 },
+  })
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return Array.isArray(data) ? data.length : 0
+}

--- a/services/users.ts
+++ b/services/users.ts
@@ -1,0 +1,24 @@
+import api from './api'
+
+export interface User {
+  id: number
+  name: string
+  email: string
+  rol?: string
+}
+
+export const fetchUsers = async (): Promise<User[]> => {
+  const res = await api.get('/users', { params: { per_page: 9999 } })
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return data as User[]
+}
+
+export const fetchCurrentUser = async (): Promise<User | null> => {
+  try {
+    const res = await api.get('/user')
+    return res.data as User
+  } catch (err) {
+    console.error('Error fetching current user', err)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- compute prospect and lead stats per user
- show metrics for the logged in advisor
- filter weekly calendar appointments to the current week

## Testing
- `npx next lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68671508072c832889775c5c062b42d7