### PR TITLE
Implement finance API integration

### DIFF
--- a/components/finanzas/conciliacion-bancaria.tsx
+++ b/components/finanzas/conciliacion-bancaria.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -37,6 +37,8 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
 import { Separator } from "@/components/ui/separator"
+import { getReconciliation, uploadReconciliation } from "@/services/finance"
+import { toast } from "@/hooks/use-toast"
 
 // Datos de ejemplo para la conciliación bancaria
 const conciliacionData = {
@@ -148,6 +150,8 @@ export function ConciliacionBancaria() {
     from: new Date(new Date().setDate(new Date().getDate() - 7)),
     to: new Date(),
   })
+  const [pendingReceipts, setPendingReceipts] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
   const [uploadForm, setUploadForm] = useState({
     studentId: "",
     bank: "",
@@ -157,6 +161,21 @@ export function ConciliacionBancaria() {
     authNumber: "",
   })
   const [selectedReceipts, setSelectedReceipts] = useState<string[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      try {
+        const data = await getReconciliation()
+        setPendingReceipts(Array.isArray(data) ? data : data.pendingReceipts)
+      } catch (e) {
+        toast({ title: 'Error', description: 'No se pudieron cargar los recibos' })
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
 
   // Función para abrir el diálogo de detalles de recibo
   const openReceiptDetailsDialog = (receipt: any) => {
@@ -189,33 +208,49 @@ export function ConciliacionBancaria() {
   // Función para seleccionar todos los recibos
   const handleSelectAllReceipts = (checked: boolean) => {
     if (checked) {
-      setSelectedReceipts(conciliacionData.pendingReceipts.map((receipt) => receipt.id))
+      setSelectedReceipts(pendingReceipts.map((receipt) => receipt.id))
     } else {
       setSelectedReceipts([])
     }
   }
 
   // Función para realizar la conciliación
-  const handleReconciliation = () => {
-    // Aquí iría la lógica real de conciliación
-    setShowReconcileDialog(false)
-    setSelectedReceipts([])
-    alert("Conciliación completada correctamente")
+  const handleReconciliation = async () => {
+    try {
+      await reconcileReceipts(selectedReceipts)
+      toast({ title: 'Conciliación completada' })
+      setShowReconcileDialog(false)
+      setSelectedReceipts([])
+    } catch (e) {
+      toast({ title: 'Error', description: 'No se pudo conciliar' })
+    }
   }
 
   // Función para subir un recibo
-  const handleUploadReceipt = () => {
-    // Aquí iría la lógica real de carga de recibo
-    setShowUploadDialog(false)
-    setUploadForm({
-      studentId: "",
-      bank: "",
-      receiptNumber: "",
-      amount: "",
-      date: "",
-      authNumber: "",
-    })
-    alert("Recibo cargado correctamente")
+  const handleUploadReceipt = async () => {
+    const formData = new FormData()
+    formData.append('student_id', uploadForm.studentId)
+    formData.append('bank', uploadForm.bank)
+    formData.append('receipt_number', uploadForm.receiptNumber)
+    formData.append('amount', uploadForm.amount)
+    formData.append('date', uploadForm.date)
+    formData.append('auth_number', uploadForm.authNumber)
+
+    try {
+      await uploadReconciliation(formData)
+      toast({ title: 'Recibo cargado correctamente' })
+      setShowUploadDialog(false)
+      setUploadForm({
+        studentId: '',
+        bank: '',
+        receiptNumber: '',
+        amount: '',
+        date: '',
+        authNumber: '',
+      })
+    } catch (e) {
+      toast({ title: 'Error', description: 'No se pudo cargar el recibo' })
+    }
   }
 
   return (
@@ -284,8 +319,8 @@ export function ConciliacionBancaria() {
                       <Checkbox
                         id="select-all"
                         checked={
-                          selectedReceipts.length === conciliacionData.pendingReceipts.length &&
-                          conciliacionData.pendingReceipts.length > 0
+                          selectedReceipts.length === pendingReceipts.length &&
+                          pendingReceipts.length > 0
                         }
                         onCheckedChange={handleSelectAllReceipts}
                       />
@@ -301,7 +336,14 @@ export function ConciliacionBancaria() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {conciliacionData.pendingReceipts.map((receipt) => (
+                  {loading ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="text-center py-4">
+                        Cargando...
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    pendingReceipts.map((receipt) => (
                     <TableRow key={receipt.id}>
                       <TableCell>
                         <Checkbox
@@ -328,13 +370,14 @@ export function ConciliacionBancaria() {
                         </Button>
                       </TableCell>
                     </TableRow>
-                  ))}
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>
             <CardFooter className="flex justify-between">
               <div className="text-sm text-muted-foreground">
-                Mostrando {conciliacionData.pendingReceipts.length} recibos pendientes
+                Mostrando {pendingReceipts.length} recibos pendientes
               </div>
               <div className="flex gap-2">
                 <Button variant="outline">
@@ -519,9 +562,9 @@ export function ConciliacionBancaria() {
                   <span className="text-sm text-muted-foreground">Monto total:</span>
                   <span className="text-sm font-medium">
                     Q
-                    {conciliacionData.pendingReceipts
+                    {pendingReceipts
                       .filter((receipt) => selectedReceipts.includes(receipt.id))
-                      .reduce((sum, receipt) => sum + receipt.amount, 0)
+                      .reduce((sum, receipt) => sum + Number(receipt.amount), 0)
                       .toLocaleString()}
                   </span>
                 </div>

--- a/components/finanzas/configuracion-reglas.tsx
+++ b/components/finanzas/configuracion-reglas.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -14,6 +14,8 @@ import { AlertCircle, Save, Plus, Trash2, Settings } from "lucide-react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
+import { getPaymentRules, updatePaymentRules } from "@/services/finance"
+import { toast } from "@/hooks/use-toast"
 
 // Datos de ejemplo para la configuración de reglas
 const rulesData = {
@@ -169,6 +171,18 @@ export function ConfiguracionReglas() {
   const [editingNotification, setEditingNotification] = useState<any | null>(null)
   const [showNotificationForm, setShowNotificationForm] = useState(false)
 
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getPaymentRules()
+        if (data) setGeneralRules(data)
+      } catch (e) {
+        toast({ title: 'Error', description: 'No se pudieron cargar las reglas' })
+      }
+    }
+    load()
+  }, [])
+
   // Función para manejar cambios en las reglas generales
   const handleGeneralRuleChange = (key: string, value: any) => {
     setGeneralRules({
@@ -191,7 +205,16 @@ export function ConfiguracionReglas() {
           <p className="text-muted-foreground">Administre las reglas de pagos, notificaciones y bloqueos</p>
         </div>
         <div className="flex items-center gap-2">
-          <Button>
+          <Button
+            onClick={async () => {
+              try {
+                await updatePaymentRules(generalRules)
+                toast({ title: 'Cambios guardados' })
+              } catch (e) {
+                toast({ title: 'Error', description: 'No se pudieron guardar los cambios' })
+              }
+            }}
+          >
             <Save className="mr-2 h-4 w-4" /> Guardar Cambios
           </Button>
         </div>
@@ -309,7 +332,16 @@ export function ConfiguracionReglas() {
               </Alert>
             </CardContent>
             <CardFooter className="flex justify-end">
-              <Button>
+              <Button
+                onClick={async () => {
+                  try {
+                    await updatePaymentRules(generalRules)
+                    toast({ title: 'Configuración guardada' })
+                  } catch (e) {
+                    toast({ title: 'Error', description: 'No se pudo guardar la configuración' })
+                  }
+                }}
+              >
                 <Save className="mr-2 h-4 w-4" /> Guardar Configuración
               </Button>
             </CardFooter>

--- a/components/finanzas/dashboard-financiero.tsx
+++ b/components/finanzas/dashboard-financiero.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
@@ -9,19 +9,11 @@ import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { fetchDashboardSummary, type DashboardSummary } from "@/services/finance"
+import { toast } from "@/hooks/use-toast"
 
 // Datos de ejemplo para el dashboard financiero
-const dashboardData = {
-  kpis: {
-    ingresosMensuales: 175000,
-    ingresosMesAnterior: 165000,
-    tasaMorosidad: 12.5,
-    tasaMorosidadAnterior: 14.2,
-    recaudacionPendiente: 45000,
-    recaudacionPendienteAnterior: 52000,
-    estudiantesActivos: 350,
-    estudiantesActivosAnterior: 340,
-  },
+const staticData = {
   morosidadPorPrograma: [
     { programa: "Desarrollo Web", porcentaje: 8.2 },
     { programa: "Diseño UX/UI", porcentaje: 10.5 },
@@ -50,6 +42,18 @@ export function DashboardFinanciero() {
     from: new Date(new Date().setDate(1)), // Primer día del mes actual
     to: new Date(),
   })
+  const [summary, setSummary] = useState<DashboardSummary | null>(null)
+
+  useEffect(() => {
+    fetchDashboardSummary()
+      .then(setSummary)
+      .catch(() =>
+        toast({
+          title: 'Error',
+          description: 'No se pudo cargar el resumen financiero',
+        }),
+      )
+  }, [])
 
   // Función para calcular el cambio porcentual
   const calcularCambio = (actual: number, anterior: number) => {
@@ -77,22 +81,18 @@ export function DashboardFinanciero() {
             <CardTitle className="text-sm font-medium text-muted-foreground">Ingresos Mensuales</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">Q {dashboardData.kpis.ingresosMensuales.toLocaleString()}</div>
+            <div className="text-2xl font-bold">Q {(summary?.ingresosMensuales ?? 0).toLocaleString()}</div>
             <div className="flex items-center mt-1">
-              {calcularCambio(dashboardData.kpis.ingresosMensuales, dashboardData.kpis.ingresosMesAnterior) > 0 ? (
+              {calcularCambio(summary?.ingresosMensuales ?? 0, summary?.ingresosMesAnterior ?? 0) > 0 ? (
                 <Badge className="bg-green-500 text-xs">
                   <ArrowUpRight className="h-3 w-3 mr-1" />
-                  {Math.abs(
-                    calcularCambio(dashboardData.kpis.ingresosMensuales, dashboardData.kpis.ingresosMesAnterior),
-                  ).toFixed(1)}
+                  {Math.abs(calcularCambio(summary?.ingresosMensuales ?? 0, summary?.ingresosMesAnterior ?? 0)).toFixed(1)}
                   %
                 </Badge>
               ) : (
                 <Badge variant="destructive" className="text-xs">
                   <ArrowDownRight className="h-3 w-3 mr-1" />
-                  {Math.abs(
-                    calcularCambio(dashboardData.kpis.ingresosMensuales, dashboardData.kpis.ingresosMesAnterior),
-                  ).toFixed(1)}
+                  {Math.abs(calcularCambio(summary?.ingresosMensuales ?? 0, summary?.ingresosMesAnterior ?? 0)).toFixed(1)}
                   %
                 </Badge>
               )}
@@ -106,22 +106,18 @@ export function DashboardFinanciero() {
             <CardTitle className="text-sm font-medium text-muted-foreground">Tasa de Morosidad</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{dashboardData.kpis.tasaMorosidad}%</div>
+            <div className="text-2xl font-bold">{summary?.tasaMorosidad ?? 0}%</div>
             <div className="flex items-center mt-1">
-              {calcularCambio(dashboardData.kpis.tasaMorosidad, dashboardData.kpis.tasaMorosidadAnterior) < 0 ? (
+              {calcularCambio(summary?.tasaMorosidad ?? 0, summary?.tasaMorosidadAnterior ?? 0) < 0 ? (
                 <Badge className="bg-green-500 text-xs">
                   <ArrowDownRight className="h-3 w-3 mr-1" />
-                  {Math.abs(
-                    calcularCambio(dashboardData.kpis.tasaMorosidad, dashboardData.kpis.tasaMorosidadAnterior),
-                  ).toFixed(1)}
+                  {Math.abs(calcularCambio(summary?.tasaMorosidad ?? 0, summary?.tasaMorosidadAnterior ?? 0)).toFixed(1)}
                   %
                 </Badge>
               ) : (
                 <Badge variant="destructive" className="text-xs">
                   <ArrowUpRight className="h-3 w-3 mr-1" />
-                  {Math.abs(
-                    calcularCambio(dashboardData.kpis.tasaMorosidad, dashboardData.kpis.tasaMorosidadAnterior),
-                  ).toFixed(1)}
+                  {Math.abs(calcularCambio(summary?.tasaMorosidad ?? 0, summary?.tasaMorosidadAnterior ?? 0)).toFixed(1)}
                   %
                 </Badge>
               )}
@@ -135,18 +131,18 @@ export function DashboardFinanciero() {
             <CardTitle className="text-sm font-medium text-muted-foreground">Recaudación Pendiente</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">Q {dashboardData.kpis.recaudacionPendiente.toLocaleString()}</div>
+            <div className="text-2xl font-bold">Q {(summary?.recaudacionPendiente ?? 0).toLocaleString()}</div>
             <div className="flex items-center mt-1">
               {calcularCambio(
-                dashboardData.kpis.recaudacionPendiente,
-                dashboardData.kpis.recaudacionPendienteAnterior,
+                summary?.recaudacionPendiente ?? 0,
+                summary?.recaudacionPendienteAnterior ?? 0,
               ) < 0 ? (
                 <Badge className="bg-green-500 text-xs">
                   <ArrowDownRight className="h-3 w-3 mr-1" />
                   {Math.abs(
                     calcularCambio(
-                      dashboardData.kpis.recaudacionPendiente,
-                      dashboardData.kpis.recaudacionPendienteAnterior,
+                      summary?.recaudacionPendiente ?? 0,
+                      summary?.recaudacionPendienteAnterior ?? 0,
                     ),
                   ).toFixed(1)}
                   %
@@ -156,8 +152,8 @@ export function DashboardFinanciero() {
                   <ArrowUpRight className="h-3 w-3 mr-1" />
                   {Math.abs(
                     calcularCambio(
-                      dashboardData.kpis.recaudacionPendiente,
-                      dashboardData.kpis.recaudacionPendienteAnterior,
+                      summary?.recaudacionPendiente ?? 0,
+                      summary?.recaudacionPendienteAnterior ?? 0,
                     ),
                   ).toFixed(1)}
                   %
@@ -173,16 +169,15 @@ export function DashboardFinanciero() {
             <CardTitle className="text-sm font-medium text-muted-foreground">Estudiantes Activos</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{dashboardData.kpis.estudiantesActivos}</div>
+            <div className="text-2xl font-bold">{summary?.estudiantesActivos ?? 0}</div>
             <div className="flex items-center mt-1">
-              {calcularCambio(dashboardData.kpis.estudiantesActivos, dashboardData.kpis.estudiantesActivosAnterior) >
-              0 ? (
+              {calcularCambio(summary?.estudiantesActivos ?? 0, summary?.estudiantesActivosAnterior ?? 0) > 0 ? (
                 <Badge className="bg-green-500 text-xs">
                   <ArrowUpRight className="h-3 w-3 mr-1" />
                   {Math.abs(
                     calcularCambio(
-                      dashboardData.kpis.estudiantesActivos,
-                      dashboardData.kpis.estudiantesActivosAnterior,
+                      summary?.estudiantesActivos ?? 0,
+                      summary?.estudiantesActivosAnterior ?? 0,
                     ),
                   ).toFixed(1)}
                   %
@@ -192,8 +187,8 @@ export function DashboardFinanciero() {
                   <ArrowDownRight className="h-3 w-3 mr-1" />
                   {Math.abs(
                     calcularCambio(
-                      dashboardData.kpis.estudiantesActivos,
-                      dashboardData.kpis.estudiantesActivosAnterior,
+                      summary?.estudiantesActivos ?? 0,
+                      summary?.estudiantesActivosAnterior ?? 0,
                     ),
                   ).toFixed(1)}
                   %
@@ -229,7 +224,7 @@ export function DashboardFinanciero() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              {dashboardData.morosidadPorPrograma.map((item) => (
+              {staticData.morosidadPorPrograma.map((item) => (
                 <div key={item.programa} className="space-y-1">
                   <div className="flex justify-between text-sm">
                     <span>{item.programa}</span>
@@ -260,7 +255,7 @@ export function DashboardFinanciero() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {dashboardData.pagosRecientes.map((pago) => (
+                {staticData.pagosRecientes.map((pago) => (
                   <TableRow key={pago.id}>
                     <TableCell className="font-medium">{pago.estudiante}</TableCell>
                     <TableCell>{pago.concepto}</TableCell>
@@ -294,7 +289,7 @@ export function DashboardFinanciero() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {dashboardData.alertasMorosidad.map((alerta) => (
+                {staticData.alertasMorosidad.map((alerta) => (
                   <TableRow key={alerta.id}>
                     <TableCell className="font-medium">{alerta.estudiante}</TableCell>
                     <TableCell>{alerta.programa}</TableCell>

--- a/components/finanzas/gestion-pagos.tsx
+++ b/components/finanzas/gestion-pagos.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -34,142 +34,10 @@ import {
 import { Progress } from "@/components/ui/progress"
 import { Textarea } from "@/components/ui/textarea"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
+import { getInvoices, getPayments, createPayment, createInvoice, updateInvoice } from "@/services/finance"
+import { toast } from "@/hooks/use-toast"
 
-// Datos de ejemplo para la gestión de pagos
-const paymentsData = {
-  lateStudents: [
-    {
-      id: "2023-0042",
-      name: "Carlos Méndez",
-      program: "Ingeniería en Sistemas",
-      totalDebt: 2850,
-      lateMonths: 2,
-      latestDueDate: "2025-02-05",
-      daysLate: 45,
-      bucket: "B3", // B1: 0-5 días, B2: 6-10 días, B3: 11-30 días, B4: +30 días
-      status: "bloqueado",
-      lastContact: "2025-03-01",
-      promiseDate: "2025-03-15",
-      contactHistory: [
-        { date: "2025-03-01", type: "llamada", notes: "Promete pagar el 15 de marzo", agent: "María López" },
-        { date: "2025-02-20", type: "email", notes: "Se envió recordatorio de pago", agent: "Sistema" },
-        { date: "2025-02-10", type: "sms", notes: "Se envió notificación de vencimiento", agent: "Sistema" },
-      ],
-    },
-    {
-      id: "2023-0078",
-      name: "Ana Lucía Gómez",
-      program: "Administración de Empresas",
-      totalDebt: 1450,
-      lateMonths: 1,
-      latestDueDate: "2025-03-05",
-      daysLate: 15,
-      bucket: "B3",
-      status: "activo",
-      lastContact: "2025-03-08",
-      promiseDate: "2025-03-20",
-      contactHistory: [
-        {
-          date: "2025-03-08",
-          type: "llamada",
-          notes: "Indica que realizará el pago el 20 de marzo",
-          agent: "Juan Pérez",
-        },
-        { date: "2025-03-06", type: "email", notes: "Se envió recordatorio de pago", agent: "Sistema" },
-      ],
-    },
-    {
-      id: "2023-0103",
-      name: "Roberto Juárez",
-      program: "Diseño Gráfico",
-      totalDebt: 4200,
-      lateMonths: 3,
-      latestDueDate: "2025-01-05",
-      daysLate: 75,
-      bucket: "B4",
-      status: "bloqueado",
-      lastContact: "2025-03-05",
-      promiseDate: null,
-      contactHistory: [
-        { date: "2025-03-05", type: "llamada", notes: "No contesta", agent: "María López" },
-        { date: "2025-02-25", type: "llamada", notes: "Número fuera de servicio", agent: "Juan Pérez" },
-        { date: "2025-02-15", type: "email", notes: "Se envió notificación de bloqueo", agent: "Sistema" },
-        { date: "2025-02-05", type: "sms", notes: "Se envió recordatorio de pago", agent: "Sistema" },
-      ],
-    },
-    {
-      id: "2023-0056",
-      name: "María Fernanda López",
-      program: "Psicología",
-      totalDebt: 1400,
-      lateMonths: 1,
-      latestDueDate: "2025-03-05",
-      daysLate: 5,
-      bucket: "B1",
-      status: "activo",
-      lastContact: null,
-      promiseDate: null,
-      contactHistory: [],
-    },
-    {
-      id: "2023-0091",
-      name: "Juan Pablo Herrera",
-      program: "Medicina",
-      totalDebt: 1450,
-      lateMonths: 1,
-      latestDueDate: "2025-03-05",
-      daysLate: 8,
-      bucket: "B2",
-      status: "activo",
-      lastContact: "2025-03-10",
-      promiseDate: "2025-03-13",
-      contactHistory: [
-        {
-          date: "2025-03-10",
-          type: "llamada",
-          notes: "Indica que realizará el pago el 13 de marzo",
-          agent: "María López",
-        },
-      ],
-    },
-  ],
-  paymentPlans: [
-    {
-      id: "PLAN-001",
-      studentId: "2023-0042",
-      studentName: "Carlos Méndez",
-      originalDebt: 2850,
-      currentDebt: 2850,
-      installments: [
-        { number: 1, amount: 950, dueDate: "2025-03-15", status: "pendiente" },
-        { number: 2, amount: 950, dueDate: "2025-04-15", status: "pendiente" },
-        { number: 3, amount: 950, dueDate: "2025-05-15", status: "pendiente" },
-      ],
-      startDate: "2025-03-10",
-      endDate: "2025-05-15",
-      status: "activo",
-      createdBy: "María López",
-      notes: "Plan de pago especial por situación económica. Documentado con carta de compromiso.",
-    },
-    {
-      id: "PLAN-002",
-      studentId: "2023-0103",
-      studentName: "Roberto Juárez",
-      originalDebt: 4200,
-      currentDebt: 2800,
-      installments: [
-        { number: 1, amount: 1400, dueDate: "2025-03-01", status: "completado" },
-        { number: 2, amount: 1400, dueDate: "2025-04-01", status: "pendiente" },
-        { number: 3, amount: 1400, dueDate: "2025-05-01", status: "pendiente" },
-      ],
-      startDate: "2025-02-20",
-      endDate: "2025-05-01",
-      status: "activo",
-      createdBy: "Juan Pérez",
-      notes: "Se desbloquea acceso después del primer pago. Debe mantenerse al día con las cuotas.",
-    },
-  ],
-}
+
 
 export function GestionPagos() {
   const [activeTab, setActiveTab] = useState("late-payments")
@@ -185,6 +53,29 @@ export function GestionPagos() {
     from: new Date(),
     to: new Date(new Date().setMonth(new Date().getMonth() + 1)),
   })
+  const [invoices, setInvoices] = useState<any[]>([])
+  const [payments, setPayments] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      try {
+        const inv = await getInvoices({})
+        const pay = await getPayments({})
+        setInvoices(inv)
+        setPayments(pay)
+      } catch (e) {
+        toast({
+          title: 'Error',
+          description: 'No se pudieron cargar los datos de pagos',
+        })
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
 
   // Función para abrir el diálogo de contacto
   const openContactDialog = (student: any) => {
@@ -350,7 +241,14 @@ export function GestionPagos() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {paymentsData.lateStudents.map((student) => (
+                  {loading ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="text-center py-4">
+                        Cargando...
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    invoices.map((student) => (
                     <TableRow key={student.id}>
                       <TableCell>
                         <Checkbox id={`select-${student.id}`} />
@@ -403,13 +301,14 @@ export function GestionPagos() {
                         </div>
                       </TableCell>
                     </TableRow>
-                  ))}
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>
             <CardFooter className="flex justify-between">
               <div className="text-sm text-muted-foreground">
-                Mostrando {paymentsData.lateStudents.length} alumnos con pagos atrasados
+                Mostrando {invoices.length} alumnos con pagos atrasados
               </div>
               <div className="flex gap-2">
                 <Button variant="outline">
@@ -452,7 +351,14 @@ export function GestionPagos() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {paymentsData.paymentPlans.map((plan) => (
+                  {loading ? (
+                    <TableRow>
+                      <TableCell colSpan={9} className="text-center py-4">
+                        Cargando...
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    payments.map((plan) => (
                     <TableRow key={plan.id}>
                       <TableCell className="font-medium">{plan.id}</TableCell>
                       <TableCell>
@@ -478,7 +384,8 @@ export function GestionPagos() {
                         </Button>
                       </TableCell>
                     </TableRow>
-                  ))}
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>
@@ -641,7 +548,19 @@ export function GestionPagos() {
             <Button variant="outline" onClick={() => setShowPaymentDialog(false)}>
               Cancelar
             </Button>
-            <Button>Registrar Pago</Button>
+            <Button
+              onClick={async () => {
+                try {
+                  await createPayment({ student_id: selectedStudent?.id })
+                  toast({ title: 'Pago registrado correctamente' })
+                  setShowPaymentDialog(false)
+                } catch (e) {
+                  toast({ title: 'Error', description: 'No se pudo registrar el pago' })
+                }
+              }}
+            >
+              Registrar Pago
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -773,7 +692,21 @@ export function GestionPagos() {
             <Button variant="outline" onClick={() => setShowPaymentPlanDialog(false)}>
               {selectedPlan ? "Cerrar" : "Cancelar"}
             </Button>
-            {!selectedPlan && <Button>Crear Plan de Pago</Button>}
+            {!selectedPlan && (
+              <Button
+                onClick={async () => {
+                  try {
+                    await createInvoice({ student_id: selectedStudent?.id })
+                    toast({ title: 'Plan de pago creado' })
+                    setShowPaymentPlanDialog(false)
+                  } catch (e) {
+                    toast({ title: 'Error', description: 'No se pudo crear el plan' })
+                  }
+                }}
+              >
+                Crear Plan de Pago
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/services/finance.ts
+++ b/services/finance.ts
@@ -1,0 +1,75 @@
+import api from './api'
+
+export interface DashboardSummary {
+  ingresosMensuales: number
+  ingresosMesAnterior: number
+  tasaMorosidad: number
+  tasaMorosidadAnterior: number
+  recaudacionPendiente: number
+  recaudacionPendienteAnterior: number
+  estudiantesActivos: number
+  estudiantesActivosAnterior: number
+}
+
+export const fetchDashboardSummary = async (): Promise<DashboardSummary> => {
+  const res = await api.get('/reports/summary')
+  return Array.isArray(res.data) ? res.data[0] : res.data
+}
+
+export const getInvoices = async (params?: any) => {
+  const res = await api.get('/invoices', { params })
+  return res.data
+}
+
+export const createInvoice = async (data: any) => {
+  const res = await api.post('/invoices', data)
+  return res.data
+}
+
+export const updateInvoice = async (id: string | number, data: any) => {
+  const res = await api.put(`/invoices/${id}`, data)
+  return res.data
+}
+
+export const deleteInvoice = async (id: string | number) => {
+  const res = await api.delete(`/invoices/${id}`)
+  return res.data
+}
+
+export const getPayments = async (params?: any) => {
+  const res = await api.get('/payments', { params })
+  return res.data
+}
+
+export const createPayment = async (data: any) => {
+  const res = await api.post('/payments', data)
+  return res.data
+}
+
+export const getPaymentRules = async () => {
+  const res = await api.get('/payment-rules')
+  return res.data
+}
+
+export const updatePaymentRules = async (data: any) => {
+  const res = await api.put('/payment-rules', data)
+  return res.data
+}
+
+export const getReconciliation = async (params?: any) => {
+  const res = await api.get('/reconciliation', { params })
+  return res.data
+}
+
+export const uploadReconciliation = async (data: FormData) => {
+  const res = await api.post('/reconciliation/upload', data, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return res.data
+}
+
+export const reconcileReceipts = async (ids: string[]) => {
+  const res = await api.post('/reconciliation', { ids })
+  return res.data
+}
+


### PR DESCRIPTION
## Summary
- add finance service with helpers for invoices, payments, rules and reconciliation
- fetch dashboard metrics from the backend
- load invoices and payments in payment manager
- integrate reconciliation API and uploads
- sync payment rules with backend

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afa704f348328b9c58f64533d8f54