### PR TITLE
Extend finance API integration

### DIFF
--- a/components/finanzas/conciliacion-bancaria.tsx
+++ b/components/finanzas/conciliacion-bancaria.tsx
@@ -37,7 +37,11 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
 import { Separator } from "@/components/ui/separator"
-import { getReconciliation, uploadReconciliation } from "@/services/finance"
+import {
+  getPendingReconciliation,
+  uploadReconciliation,
+  processReconciliation,
+} from "@/services/finance"
 import { toast } from "@/hooks/use-toast"
 
 // Datos de ejemplo para la conciliación bancaria
@@ -166,7 +170,7 @@ export function ConciliacionBancaria() {
     const load = async () => {
       setLoading(true)
       try {
-        const data = await getReconciliation()
+        const data = await getPendingReconciliation()
         setPendingReceipts(Array.isArray(data) ? data : data.pendingReceipts)
       } catch (e) {
         toast({ title: 'Error', description: 'No se pudieron cargar los recibos' })
@@ -217,7 +221,7 @@ export function ConciliacionBancaria() {
   // Función para realizar la conciliación
   const handleReconciliation = async () => {
     try {
-      await reconcileReceipts(selectedReceipts)
+      await processReconciliation()
       toast({ title: 'Conciliación completada' })
       setShowReconcileDialog(false)
       setSelectedReceipts([])

--- a/components/finanzas/gestion-pagos.tsx
+++ b/components/finanzas/gestion-pagos.tsx
@@ -34,7 +34,16 @@ import {
 import { Progress } from "@/components/ui/progress"
 import { Textarea } from "@/components/ui/textarea"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
-import { getInvoices, getPayments, createPayment, createInvoice, updateInvoice } from "@/services/finance"
+import {
+  getInvoices,
+  getPayments,
+  createPayment,
+  
+  getPaymentPlans,
+  createPaymentPlan,
+  getCollectionLogs,
+  createCollectionLog,
+} from "@/services/finance"
 import { toast } from "@/hooks/use-toast"
 
 
@@ -55,16 +64,24 @@ export function GestionPagos() {
   })
   const [invoices, setInvoices] = useState<any[]>([])
   const [payments, setPayments] = useState<any[]>([])
+  const [paymentPlans, setPaymentPlans] = useState<any[]>([])
+  const [collectionLogs, setCollectionLogs] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const load = async () => {
       setLoading(true)
       try {
-        const inv = await getInvoices({})
-        const pay = await getPayments({})
+        const [inv, pay, plans, logs] = await Promise.all([
+          getInvoices({}),
+          getPayments({}),
+          getPaymentPlans({}),
+          getCollectionLogs({}),
+        ])
         setInvoices(inv)
         setPayments(pay)
+        setPaymentPlans(plans)
+        setCollectionLogs(Array.isArray(logs.data) ? logs.data : logs)
       } catch (e) {
         toast({
           title: 'Error',
@@ -358,7 +375,7 @@ export function GestionPagos() {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    payments.map((plan) => (
+                    paymentPlans.map((plan) => (
                     <TableRow key={plan.id}>
                       <TableCell className="font-medium">{plan.id}</TableCell>
                       <TableCell>
@@ -696,7 +713,7 @@ export function GestionPagos() {
               <Button
                 onClick={async () => {
                   try {
-                    await createInvoice({ student_id: selectedStudent?.id })
+                    await createPaymentPlan({ prospecto_id: selectedStudent?.id })
                     toast({ title: 'Plan de pago creado' })
                     setShowPaymentPlanDialog(false)
                   } catch (e) {

--- a/services/api.ts
+++ b/services/api.ts
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '@/utils/apiConfig';
 // Create axios instance with environment variable
 export const api = axios.create({
   baseURL: `${API_BASE_URL}/api`,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/services/finance.ts
+++ b/services/finance.ts
@@ -56,8 +56,8 @@ export const updatePaymentRules = async (data: any) => {
   return res.data
 }
 
-export const getReconciliation = async (params?: any) => {
-  const res = await api.get('/reconciliation', { params })
+export const getPendingReconciliation = async () => {
+  const res = await api.get('/reconciliation/pending')
   return res.data
 }
 
@@ -68,8 +68,87 @@ export const uploadReconciliation = async (data: FormData) => {
   return res.data
 }
 
-export const reconcileReceipts = async (ids: string[]) => {
-  const res = await api.post('/reconciliation', { ids })
+export const processReconciliation = async () => {
+  const res = await api.post('/reconciliation/process')
+  return res.data
+}
+
+export const getPaymentPlans = async (params?: any) => {
+  const res = await api.get('/payment-plans', { params })
+  return res.data
+}
+
+export const createPaymentPlan = async (data: any) => {
+  const res = await api.post('/payment-plans', data)
+  return res.data
+}
+
+export const updatePaymentPlan = async (id: string | number, data: any) => {
+  const res = await api.put(`/payment-plans/${id}`, data)
+  return res.data
+}
+
+export const deletePaymentPlan = async (id: string | number) => {
+  const res = await api.delete(`/payment-plans/${id}`)
+  return res.data
+}
+
+export const getInstallments = async (planId: string | number) => {
+  const res = await api.get(`/payment-plans/${planId}/installments`)
+  return res.data
+}
+
+export const createInstallment = async (
+  planId: string | number,
+  data: any,
+) => {
+  const res = await api.post(`/payment-plans/${planId}/installments`, data)
+  return res.data
+}
+
+export const updateInstallment = async (
+  installmentId: string | number,
+  data: any,
+) => {
+  const res = await api.put(`/payment-plans/installments/${installmentId}`, data)
+  return res.data
+}
+
+export const deleteInstallment = async (installmentId: string | number) => {
+  const res = await api.delete(
+    `/payment-plans/installments/${installmentId}`,
+  )
+  return res.data
+}
+
+export const getCollectionLogs = async (params?: any) => {
+  const res = await api.get('/collection-logs', { params })
+  return res.data
+}
+
+export const createCollectionLog = async (data: any) => {
+  const res = await api.post('/collection-logs', data)
+  return res.data
+}
+
+export const updateCollectionLog = async (id: string | number, data: any) => {
+  const res = await api.put(`/collection-logs/${id}`, data)
+  return res.data
+}
+
+export const deleteCollectionLog = async (id: string | number) => {
+  const res = await api.delete(`/collection-logs/${id}`)
+  return res.data
+}
+
+export const exportFinancialReport = async (
+  format: 'pdf' | 'excel',
+  queue?: boolean,
+) => {
+  const res = await api.get('/reports/export', {
+    params: { format, ...(queue ? { queue: 1 } : {}) },
+    responseType: queue ? 'json' : 'blob',
+  })
   return res.data
 }
 


### PR DESCRIPTION
## Summary
- enable credentials on axios instance
- update reconciliation service calls
- add payment plan and collection log services
- fetch payment plans and logs in GestionPagos
- adapt Reconciliation page to new API routes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b2443b6ec8328a26b73d33f6af3a5