### PR TITLE
Extend finance API integration

### DIFF
--- a/components/finanzas/conciliacion-bancaria.tsx
+++ b/components/finanzas/conciliacion-bancaria.tsx
@@ -37,107 +37,14 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
 import { Separator } from "@/components/ui/separator"
-import { getReconciliation, uploadReconciliation } from "@/services/finance"
+import {
+  getPendingReconciliation,
+  uploadReconciliation,
+  processReconciliation,
+} from "@/services/finance"
 import { toast } from "@/hooks/use-toast"
 
-// Datos de ejemplo para la conciliación bancaria
-const conciliacionData = {
-  pendingReceipts: [
-    {
-      id: "rec-001",
-      studentId: "2023-0042",
-      studentName: "Carlos Méndez",
-      bank: "Banco Industrial",
-      receiptNumber: "BI-123456",
-      amount: 750,
-      date: "2025-03-10",
-      authNumber: "AUTH-987654",
-      status: "pendiente",
-      uploadDate: "2025-03-10",
-      program: "Desarrollo Web Full Stack",
-    },
-    {
-      id: "rec-002",
-      studentId: "2023-0078",
-      studentName: "Ana Lucía Gómez",
-      bank: "Banrural",
-      receiptNumber: "BR-654321",
-      amount: 750,
-      date: "2025-03-09",
-      authNumber: "AUTH-123456",
-      status: "pendiente",
-      uploadDate: "2025-03-09",
-      program: "Diseño UX/UI",
-    },
-    {
-      id: "rec-003",
-      studentId: "2023-0091",
-      studentName: "Juan Pablo Herrera",
-      bank: "Banco G&T",
-      receiptNumber: "GT-789456",
-      amount: 750,
-      date: "2025-03-08",
-      authNumber: "AUTH-456789",
-      status: "pendiente",
-      uploadDate: "2025-03-08",
-      program: "Medicina",
-    },
-  ],
-  reconciliationHistory: [
-    {
-      id: "recon-001",
-      date: "2025-03-09",
-      totalReceipts: 15,
-      totalAmount: 11250,
-      status: "completada",
-      processedBy: "María López",
-      receipts: [
-        {
-          id: "rec-004",
-          studentId: "2023-0056",
-          studentName: "María Fernanda López",
-          bank: "Banco Industrial",
-          receiptNumber: "BI-789123",
-          amount: 750,
-          date: "2025-03-05",
-          authNumber: "AUTH-321654",
-          status: "conciliado",
-          uploadDate: "2025-03-05",
-          program: "Psicología",
-        },
-        {
-          id: "rec-005",
-          studentId: "2023-0112",
-          studentName: "Lucía Ramírez",
-          bank: "Banrural",
-          receiptNumber: "BR-456789",
-          amount: 750,
-          date: "2025-03-05",
-          authNumber: "AUTH-987321",
-          status: "conciliado",
-          uploadDate: "2025-03-05",
-          program: "Administración de Empresas",
-        },
-      ],
-    },
-    {
-      id: "recon-002",
-      date: "2025-03-08",
-      totalReceipts: 12,
-      totalAmount: 9000,
-      status: "completada",
-      processedBy: "Juan Pérez",
-      receipts: [],
-    },
-  ],
-  banks: [
-    { id: "bank-001", name: "Banco Industrial" },
-    { id: "bank-002", name: "Banrural" },
-    { id: "bank-003", name: "Banco G&T" },
-    { id: "bank-004", name: "BAC Credomatic" },
-    { id: "bank-005", name: "Banco Promerica" },
-  ],
-}
+// Datos cargados desde la API de conciliación
 
 export function ConciliacionBancaria() {
   const [activeTab, setActiveTab] = useState("pending-receipts")
@@ -151,6 +58,8 @@ export function ConciliacionBancaria() {
     to: new Date(),
   })
   const [pendingReceipts, setPendingReceipts] = useState<any[]>([])
+  const [reconciliationHistory, setReconciliationHistory] = useState<any[]>([])
+  const [banks, setBanks] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [uploadForm, setUploadForm] = useState({
     studentId: "",
@@ -166,8 +75,14 @@ export function ConciliacionBancaria() {
     const load = async () => {
       setLoading(true)
       try {
-        const data = await getReconciliation()
-        setPendingReceipts(Array.isArray(data) ? data : data.pendingReceipts)
+        const data = await getPendingReconciliation()
+        if (Array.isArray(data)) {
+          setPendingReceipts(data)
+        } else if (data) {
+          setPendingReceipts(data.pendingReceipts || [])
+          setReconciliationHistory(data.reconciliationHistory || [])
+          setBanks(data.banks || [])
+        }
       } catch (e) {
         toast({ title: 'Error', description: 'No se pudieron cargar los recibos' })
       } finally {
@@ -217,7 +132,7 @@ export function ConciliacionBancaria() {
   // Función para realizar la conciliación
   const handleReconciliation = async () => {
     try {
-      await reconcileReceipts(selectedReceipts)
+      await processReconciliation()
       toast({ title: 'Conciliación completada' })
       setShowReconcileDialog(false)
       setSelectedReceipts([])
@@ -301,7 +216,7 @@ export function ConciliacionBancaria() {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="all">Todos los bancos</SelectItem>
-                      {conciliacionData.banks.map((bank) => (
+                      {banks.map((bank) => (
                         <SelectItem key={bank.id} value={bank.id}>
                           {bank.name}
                         </SelectItem>
@@ -415,7 +330,7 @@ export function ConciliacionBancaria() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {conciliacionData.reconciliationHistory.map((reconciliation) => (
+                  {reconciliationHistory.map((reconciliation) => (
                     <TableRow key={reconciliation.id}>
                       <TableCell>
                         <div className="flex items-center gap-1">
@@ -475,7 +390,7 @@ export function ConciliacionBancaria() {
                   <SelectValue placeholder="Seleccione el banco" />
                 </SelectTrigger>
                 <SelectContent>
-                  {conciliacionData.banks.map((bank) => (
+                  {banks.map((bank) => (
                     <SelectItem key={bank.id} value={bank.id}>
                       {bank.name}
                     </SelectItem>

--- a/components/finanzas/configuracion-reglas.tsx
+++ b/components/finanzas/configuracion-reglas.tsx
@@ -175,7 +175,10 @@ export function ConfiguracionReglas() {
     const load = async () => {
       try {
         const data = await getPaymentRules()
-        if (data) setGeneralRules(data)
+        if (data) {
+          const rule = Array.isArray(data) ? data[0] : data
+          setGeneralRules((prev) => ({ ...prev, ...rule }))
+        }
       } catch (e) {
         toast({ title: 'Error', description: 'No se pudieron cargar las reglas' })
       }
@@ -245,8 +248,13 @@ export function ConfiguracionReglas() {
                       type="number"
                       min="1"
                       max="28"
-                      value={generalRules.dueDateDay}
-                      onChange={(e) => handleGeneralRuleChange("dueDateDay", Number.parseInt(e.target.value))}
+                      value={generalRules.dueDateDay ?? ""}
+                      onChange={(e) =>
+                        handleGeneralRuleChange(
+                          "dueDateDay",
+                          e.target.value === "" ? undefined : Number(e.target.value),
+                        )
+                      }
                     />
                     <p className="text-xs text-muted-foreground">Día del mes en que vencen los pagos mensuales</p>
                   </div>
@@ -257,8 +265,13 @@ export function ConfiguracionReglas() {
                       id="lateFeeAmount"
                       type="number"
                       min="0"
-                      value={generalRules.lateFeeAmount}
-                      onChange={(e) => handleGeneralRuleChange("lateFeeAmount", Number.parseInt(e.target.value))}
+                      value={generalRules.lateFeeAmount ?? ""}
+                      onChange={(e) =>
+                        handleGeneralRuleChange(
+                          "lateFeeAmount",
+                          e.target.value === "" ? undefined : Number(e.target.value),
+                        )
+                      }
                     />
                     <p className="text-xs text-muted-foreground">
                       Cantidad que se cargará automáticamente por pagos atrasados
@@ -272,8 +285,13 @@ export function ConfiguracionReglas() {
                       type="number"
                       min="1"
                       max="12"
-                      value={generalRules.blockAfterMonths}
-                      onChange={(e) => handleGeneralRuleChange("blockAfterMonths", Number.parseInt(e.target.value))}
+                      value={generalRules.blockAfterMonths ?? ""}
+                      onChange={(e) =>
+                        handleGeneralRuleChange(
+                          "blockAfterMonths",
+                          e.target.value === "" ? undefined : Number(e.target.value),
+                        )
+                      }
                     />
                     <p className="text-xs text-muted-foreground">
                       Número de meses sin pago antes de bloquear la plataforma

--- a/components/finanzas/gestion-pagos.tsx
+++ b/components/finanzas/gestion-pagos.tsx
@@ -34,7 +34,16 @@ import {
 import { Progress } from "@/components/ui/progress"
 import { Textarea } from "@/components/ui/textarea"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
-import { getInvoices, getPayments, createPayment, createInvoice, updateInvoice } from "@/services/finance"
+import {
+  getInvoices,
+  getPayments,
+  createPayment,
+  
+  getPaymentPlans,
+  createPaymentPlan,
+  getCollectionLogs,
+  createCollectionLog,
+} from "@/services/finance"
 import { toast } from "@/hooks/use-toast"
 
 
@@ -55,16 +64,24 @@ export function GestionPagos() {
   })
   const [invoices, setInvoices] = useState<any[]>([])
   const [payments, setPayments] = useState<any[]>([])
+  const [paymentPlans, setPaymentPlans] = useState<any[]>([])
+  const [collectionLogs, setCollectionLogs] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const load = async () => {
       setLoading(true)
       try {
-        const inv = await getInvoices({})
-        const pay = await getPayments({})
+        const [inv, pay, plans, logs] = await Promise.all([
+          getInvoices({}),
+          getPayments({}),
+          getPaymentPlans({}),
+          getCollectionLogs({}),
+        ])
         setInvoices(inv)
         setPayments(pay)
+        setPaymentPlans(plans)
+        setCollectionLogs(Array.isArray(logs.data) ? logs.data : logs)
       } catch (e) {
         toast({
           title: 'Error',
@@ -358,7 +375,7 @@ export function GestionPagos() {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    payments.map((plan) => (
+                    paymentPlans.map((plan) => (
                     <TableRow key={plan.id}>
                       <TableCell className="font-medium">{plan.id}</TableCell>
                       <TableCell>
@@ -696,7 +713,7 @@ export function GestionPagos() {
               <Button
                 onClick={async () => {
                   try {
-                    await createInvoice({ student_id: selectedStudent?.id })
+                    await createPaymentPlan({ prospecto_id: selectedStudent?.id })
                     toast({ title: 'Plan de pago creado' })
                     setShowPaymentPlanDialog(false)
                   } catch (e) {

--- a/components/finanzas/reportes-financieros.tsx
+++ b/components/finanzas/reportes-financieros.tsx
@@ -21,7 +21,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { Progress } from "@/components/ui/progress"
+import { exportFinancialReport } from "@/services/finance"
 
 // Datos de ejemplo para los reportes financieros
 const reportesData = {
@@ -159,7 +159,6 @@ const GeneradorEstadosCuenta = () => {
   const [selectedStudents, setSelectedStudents] = useState<string[]>([])
   const [searchQuery, setSearchQuery] = useState("")
   const [isGenerating, setIsGenerating] = useState(false)
-  const [generationProgress, setGenerationProgress] = useState(0)
   const [showPreview, setShowPreview] = useState(false)
   const [previewStudent, setPreviewStudent] = useState<any | null>(null)
 
@@ -190,27 +189,23 @@ const GeneradorEstadosCuenta = () => {
   )
 
   // Función para generar estados de cuenta
-  const generateAccountStatements = () => {
+  const [format, setFormat] = useState<'pdf' | 'excel'>('pdf')
+  const generateAccountStatements = async () => {
     if (selectedStudents.length === 0) {
-      alert("Por favor seleccione al menos un estudiante")
+      alert('Por favor seleccione al menos un estudiante')
       return
     }
 
     setIsGenerating(true)
-    setGenerationProgress(0)
-
-    // Simulación de generación de reportes
-    const interval = setInterval(() => {
-      setGenerationProgress((prev) => {
-        if (prev >= 100) {
-          clearInterval(interval)
-          setIsGenerating(false)
-          alert(`Se han generado ${selectedStudents.length} estados de cuenta correctamente`)
-          return 0
-        }
-        return prev + 5
-      })
-    }, 100)
+    try {
+      const blob = await exportFinancialReport(format)
+      const url = URL.createObjectURL(blob)
+      window.open(url)
+    } catch (e) {
+      alert('No se pudo generar el reporte')
+    } finally {
+      setIsGenerating(false)
+    }
   }
 
   // Función para mostrar vista previa
@@ -306,26 +301,19 @@ const GeneradorEstadosCuenta = () => {
           </Table>
 
           {isGenerating && (
-            <div className="mt-4 space-y-2">
-              <div className="flex justify-between text-sm">
-                <span>Generando estados de cuenta...</span>
-                <span>{generationProgress}%</span>
-              </div>
-              <Progress value={generationProgress} className="h-2" />
-            </div>
+            <div className="mt-4 text-sm">Generando reporte...</div>
           )}
         </CardContent>
         <CardFooter className="flex justify-between">
           <div className="text-sm text-muted-foreground">{selectedStudents.length} estudiantes seleccionados</div>
           <div className="flex gap-2">
-            <Select defaultValue="pdf">
+            <Select value={format} onValueChange={(v) => setFormat(v as 'pdf' | 'excel')}>
               <SelectTrigger className="w-[130px]">
                 <SelectValue placeholder="Formato" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="pdf">PDF</SelectItem>
                 <SelectItem value="excel">Excel</SelectItem>
-                <SelectItem value="csv">CSV</SelectItem>
               </SelectContent>
             </Select>
             <Button onClick={generateAccountStatements} disabled={isGenerating || selectedStudents.length === 0}>
@@ -480,7 +468,13 @@ const GeneradorEstadosCuenta = () => {
             <Button variant="outline" onClick={() => setShowPreview(false)}>
               Cerrar
             </Button>
-            <Button>
+            <Button
+              onClick={async () => {
+                const blob = await exportFinancialReport('pdf')
+                const url = URL.createObjectURL(blob)
+                window.open(url)
+              }}
+            >
               <Download className="mr-2 h-4 w-4" /> Descargar PDF
             </Button>
           </DialogFooter>
@@ -498,7 +492,6 @@ const GeneradorLibrosContables = () => {
   })
   const [selectedBooks, setSelectedBooks] = useState<string[]>([])
   const [isGenerating, setIsGenerating] = useState(false)
-  const [generationProgress, setGenerationProgress] = useState(0)
   const [showPreview, setShowPreview] = useState(false)
   const [previewBook, setPreviewBook] = useState<any | null>(null)
 
@@ -521,27 +514,22 @@ const GeneradorLibrosContables = () => {
   }
 
   // Función para generar libros contables
-  const generateAccountingBooks = () => {
+  const generateAccountingBooks = async () => {
     if (selectedBooks.length === 0) {
-      alert("Por favor seleccione al menos un libro contable")
+      alert('Por favor seleccione al menos un libro contable')
       return
     }
 
     setIsGenerating(true)
-    setGenerationProgress(0)
-
-    // Simulación de generación de libros
-    const interval = setInterval(() => {
-      setGenerationProgress((prev) => {
-        if (prev >= 100) {
-          clearInterval(interval)
-          setIsGenerating(false)
-          alert(`Se han generado ${selectedBooks.length} libros contables correctamente`)
-          return 0
-        }
-        return prev + 5
-      })
-    }, 100)
+    try {
+      const blob = await exportFinancialReport(format)
+      const url = URL.createObjectURL(blob)
+      window.open(url)
+    } catch (e) {
+      alert('No se pudo generar el reporte')
+    } finally {
+      setIsGenerating(false)
+    }
   }
 
   // Función para mostrar vista previa
@@ -617,26 +605,19 @@ const GeneradorLibrosContables = () => {
           </Table>
 
           {isGenerating && (
-            <div className="mt-4 space-y-2">
-              <div className="flex justify-between text-sm">
-                <span>Generando libros contables...</span>
-                <span>{generationProgress}%</span>
-              </div>
-              <Progress value={generationProgress} className="h-2" />
-            </div>
+            <div className="mt-4 text-sm">Generando reporte...</div>
           )}
         </CardContent>
         <CardFooter className="flex justify-between">
           <div className="text-sm text-muted-foreground">{selectedBooks.length} libros seleccionados</div>
           <div className="flex gap-2">
-            <Select defaultValue="pdf">
+            <Select value={format} onValueChange={(v) => setFormat(v as 'pdf' | 'excel')}>
               <SelectTrigger className="w-[130px]">
                 <SelectValue placeholder="Formato" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="pdf">PDF</SelectItem>
                 <SelectItem value="excel">Excel</SelectItem>
-                <SelectItem value="csv">CSV</SelectItem>
               </SelectContent>
             </Select>
             <Button onClick={generateAccountingBooks} disabled={isGenerating || selectedBooks.length === 0}>
@@ -973,7 +954,13 @@ const GeneradorLibrosContables = () => {
             <Button variant="outline" onClick={() => setShowPreview(false)}>
               Cerrar
             </Button>
-            <Button>
+            <Button
+              onClick={async () => {
+                const blob = await exportFinancialReport('pdf')
+                const url = URL.createObjectURL(blob)
+                window.open(url)
+              }}
+            >
               <Download className="mr-2 h-4 w-4" /> Descargar PDF
             </Button>
           </DialogFooter>

--- a/services/api.ts
+++ b/services/api.ts
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '@/utils/apiConfig';
 // Create axios instance with environment variable
 export const api = axios.create({
   baseURL: `${API_BASE_URL}/api`,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/services/finance.ts
+++ b/services/finance.ts
@@ -56,8 +56,8 @@ export const updatePaymentRules = async (data: any) => {
   return res.data
 }
 
-export const getReconciliation = async (params?: any) => {
-  const res = await api.get('/reconciliation', { params })
+export const getPendingReconciliation = async () => {
+  const res = await api.get('/reconciliation/pending')
   return res.data
 }
 
@@ -68,8 +68,87 @@ export const uploadReconciliation = async (data: FormData) => {
   return res.data
 }
 
-export const reconcileReceipts = async (ids: string[]) => {
-  const res = await api.post('/reconciliation', { ids })
+export const processReconciliation = async () => {
+  const res = await api.post('/reconciliation/process')
+  return res.data
+}
+
+export const getPaymentPlans = async (params?: any) => {
+  const res = await api.get('/payment-plans', { params })
+  return res.data
+}
+
+export const createPaymentPlan = async (data: any) => {
+  const res = await api.post('/payment-plans', data)
+  return res.data
+}
+
+export const updatePaymentPlan = async (id: string | number, data: any) => {
+  const res = await api.put(`/payment-plans/${id}`, data)
+  return res.data
+}
+
+export const deletePaymentPlan = async (id: string | number) => {
+  const res = await api.delete(`/payment-plans/${id}`)
+  return res.data
+}
+
+export const getInstallments = async (planId: string | number) => {
+  const res = await api.get(`/payment-plans/${planId}/installments`)
+  return res.data
+}
+
+export const createInstallment = async (
+  planId: string | number,
+  data: any,
+) => {
+  const res = await api.post(`/payment-plans/${planId}/installments`, data)
+  return res.data
+}
+
+export const updateInstallment = async (
+  installmentId: string | number,
+  data: any,
+) => {
+  const res = await api.put(`/payment-plans/installments/${installmentId}`, data)
+  return res.data
+}
+
+export const deleteInstallment = async (installmentId: string | number) => {
+  const res = await api.delete(
+    `/payment-plans/installments/${installmentId}`,
+  )
+  return res.data
+}
+
+export const getCollectionLogs = async (params?: any) => {
+  const res = await api.get('/collection-logs', { params })
+  return res.data
+}
+
+export const createCollectionLog = async (data: any) => {
+  const res = await api.post('/collection-logs', data)
+  return res.data
+}
+
+export const updateCollectionLog = async (id: string | number, data: any) => {
+  const res = await api.put(`/collection-logs/${id}`, data)
+  return res.data
+}
+
+export const deleteCollectionLog = async (id: string | number) => {
+  const res = await api.delete(`/collection-logs/${id}`)
+  return res.data
+}
+
+export const exportFinancialReport = async (
+  format: 'pdf' | 'excel',
+  queue?: boolean,
+) => {
+  const res = await api.get('/reports/export', {
+    params: { format, ...(queue ? { queue: 1 } : {}) },
+    responseType: queue ? 'json' : 'blob',
+  })
   return res.data
 }
 


### PR DESCRIPTION
## Summary
- remove placeholder data from reconciliation page and load from API
- keep number inputs controlled in payment rules configuration
- allow exporting financial reports

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_686b2443b6ec8328a26b73d33f6af3a5