### PR TITLE
Fix financial data integration

### DIFF
--- a/components/finanzas/configuracion-reglas.tsx
+++ b/components/finanzas/configuracion-reglas.tsx
@@ -17,159 +17,23 @@ import { Badge } from "@/components/ui/badge"
 import { getPaymentRules, updatePaymentRules } from "@/services/finance"
 import { toast } from "@/hooks/use-toast"
 
-// Datos de ejemplo para la configuración de reglas
-const rulesData = {
-  generalRules: {
-    dueDateDay: 5,
-    lateFeeAmount: 50,
-    blockAfterMonths: 2,
-    sendAutomaticReminders: true,
-    allowPartialPayments: false,
-    requireReceiptUpload: true,
-    autoUnblockAfterPayment: true,
-  },
-  notificationRules: [
-    {
-      id: "not-1",
-      name: "Recordatorio previo",
-      type: "email",
-      triggerDays: -3,
-      message: "Recordatorio: Su pago vence en 3 días. Por favor, realice su pago a tiempo para evitar recargos.",
-      active: true,
-    },
-    {
-      id: "not-2",
-      name: "Día de vencimiento",
-      type: "sms",
-      triggerDays: 0,
-      message: "Hoy vence su pago mensual. Realice su pago para evitar recargos por mora.",
-      active: true,
-    },
-    {
-      id: "not-3",
-      name: "Primer recordatorio",
-      type: "email",
-      triggerDays: 1,
-      message:
-        "Su pago está vencido por 1 día. Por favor, realice su pago lo antes posible para evitar recargos adicionales.",
-      active: true,
-    },
-    {
-      id: "not-4",
-      name: "Aviso de recargo",
-      type: "sms",
-      triggerDays: 5,
-      message: "Su pago está vencido por 5 días. Se ha aplicado un recargo de Q50 a su cuenta.",
-      active: true,
-    },
-    {
-      id: "not-5",
-      name: "Aviso de bloqueo",
-      type: "email",
-      triggerDays: 45,
-      message:
-        "Su cuenta será bloqueada en 15 días si no realiza el pago pendiente. Por favor, regularice su situación.",
-      active: true,
-    },
-  ],
-  blockingRules: [
-    {
-      id: "block-1",
-      name: "Bloqueo por mora",
-      description: "Bloqueo automático después de 2 meses sin pago",
-      daysAfterDue: 60,
-      services: ["plataforma", "evaluaciones", "materiales"],
-      active: true,
-    },
-    {
-      id: "block-2",
-      name: "Bloqueo parcial",
-      description: "Bloqueo de evaluaciones después de 1 mes sin pago",
-      daysAfterDue: 30,
-      services: ["evaluaciones"],
-      active: true,
-    },
-  ],
-  paymentGateways: [
-    {
-      id: "pg-1",
-      name: "Pagalo",
-      description: "Pasarela de pago Pagalo",
-      active: true,
-      fee: 4.5,
-      apiKey: "********",
-      merchantId: "MERCHANT123",
-    },
-    {
-      id: "pg-2",
-      name: "VisaNet",
-      description: "Pasarela de pago VisaNet",
-      active: true,
-      fee: 3.8,
-      apiKey: "********",
-      merchantId: "VISANET456",
-    },
-    {
-      id: "pg-3",
-      name: "Stripe",
-      description: "Pasarela de pago Stripe",
-      active: false,
-      fee: 2.9,
-      apiKey: "",
-      merchantId: "",
-    },
-    {
-      id: "pg-4",
-      name: "NeoNet",
-      description: "Pasarela de pago NeoNet",
-      active: false,
-      fee: 3.5,
-      apiKey: "",
-      merchantId: "",
-    },
-  ],
-  exceptionCategories: [
-    {
-      id: "exc-1",
-      name: "Becados",
-      description: "Alumnos con beca completa o parcial",
-      rules: {
-        skipLateFee: true,
-        extendedDueDate: 15,
-        allowPartialPayments: true,
-        skipBlocking: false,
-      },
-    },
-    {
-      id: "exc-2",
-      name: "Convenios Empresariales",
-      description: "Alumnos con convenio a través de empresas",
-      rules: {
-        skipLateFee: false,
-        extendedDueDate: 10,
-        allowPartialPayments: false,
-        skipBlocking: true,
-      },
-    },
-    {
-      id: "exc-3",
-      name: "Casos Especiales",
-      description: "Alumnos con situaciones particulares aprobadas",
-      rules: {
-        skipLateFee: true,
-        extendedDueDate: 20,
-        allowPartialPayments: true,
-        skipBlocking: true,
-      },
-    },
-  ],
-}
 
 export function ConfiguracionReglas() {
   const [activeTab, setActiveTab] = useState("general")
-  const [generalRules, setGeneralRules] = useState(rulesData.generalRules)
+  const [generalRules, setGeneralRules] = useState<any>({})
+  const [notificationRules, setNotificationRules] = useState<any[]>([])
+  const [blockingRules, setBlockingRules] = useState<any[]>([])
+  const [paymentGateways, setPaymentGateways] = useState<any[]>([])
+  const [exceptionCategories, setExceptionCategories] = useState<any[]>([])
   const [editingNotification, setEditingNotification] = useState<any | null>(null)
   const [showNotificationForm, setShowNotificationForm] = useState(false)
+  const [notificationForm, setNotificationForm] = useState({
+    name: '',
+    type: 'email',
+    triggerDays: 0,
+    active: true,
+    message: '',
+  })
 
   useEffect(() => {
     const load = async () => {
@@ -178,6 +42,10 @@ export function ConfiguracionReglas() {
         if (data) {
           const rule = Array.isArray(data) ? data[0] : data
           setGeneralRules((prev) => ({ ...prev, ...rule }))
+          setNotificationRules(rule.notificationRules || [])
+          setBlockingRules(rule.blockingRules || [])
+          setPaymentGateways(rule.paymentGateways || [])
+          setExceptionCategories(rule.exceptionCategories || [])
         }
       } catch (e) {
         toast({ title: 'Error', description: 'No se pudieron cargar las reglas' })
@@ -197,6 +65,17 @@ export function ConfiguracionReglas() {
   // Función para abrir el formulario de notificación
   const openNotificationForm = (notification: any = null) => {
     setEditingNotification(notification)
+    if (notification) {
+      setNotificationForm({
+        name: notification.name,
+        type: notification.type,
+        triggerDays: notification.triggerDays,
+        active: notification.active,
+        message: notification.message,
+      })
+    } else {
+      setNotificationForm({ name: '', type: 'email', triggerDays: 0, active: true, message: '' })
+    }
     setShowNotificationForm(true)
   }
 
@@ -211,7 +90,13 @@ export function ConfiguracionReglas() {
           <Button
             onClick={async () => {
               try {
-                await updatePaymentRules(generalRules)
+                await updatePaymentRules(generalRules.id ?? 1, {
+                  ...generalRules,
+                  notificationRules,
+                  blockingRules,
+                  paymentGateways,
+                  exceptionCategories,
+                })
                 toast({ title: 'Cambios guardados' })
               } catch (e) {
                 toast({ title: 'Error', description: 'No se pudieron guardar los cambios' })
@@ -359,7 +244,13 @@ export function ConfiguracionReglas() {
               <Button
                 onClick={async () => {
                   try {
-                    await updatePaymentRules(generalRules)
+                await updatePaymentRules(generalRules.id ?? 1, {
+                      ...generalRules,
+                      notificationRules,
+                      blockingRules,
+                      paymentGateways,
+                      exceptionCategories,
+                    })
                     toast({ title: 'Configuración guardada' })
                   } catch (e) {
                     toast({ title: 'Error', description: 'No se pudo guardar la configuración' })
@@ -397,43 +288,53 @@ export function ConfiguracionReglas() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {rulesData.notificationRules.map((notification) => (
-                    <TableRow key={notification.id}>
-                      <TableCell>
-                        <Checkbox id={`select-${notification.id}`} />
-                      </TableCell>
-                      <TableCell className="font-medium">{notification.name}</TableCell>
-                      <TableCell>
-                        <Badge variant="outline">
-                          {notification.type === "email" ? "Email" : notification.type === "sms" ? "SMS" : "WhatsApp"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        {notification.triggerDays === 0
-                          ? "Día de vencimiento"
-                          : notification.triggerDays < 0
-                            ? `${Math.abs(notification.triggerDays)} días antes`
-                            : `${notification.triggerDays} días después`}
-                      </TableCell>
-                      <TableCell className="max-w-[300px] truncate">{notification.message}</TableCell>
-                      <TableCell>
-                        <Badge variant={notification.active ? "default" : "outline"}>
-                          {notification.active ? "Activo" : "Inactivo"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <Button variant="ghost" size="sm" onClick={() => openNotificationForm(notification)}>
-                          <Settings className="h-4 w-4 mr-1" /> Editar
-                        </Button>
+                  {notificationRules.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6} className="text-center">
+                        Sin datos
                       </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    notificationRules.map((notification) => {
+                      return (
+                        <TableRow key={notification.id}>
+                          <TableCell>
+                            <Checkbox id={`select-${notification.id}`} />
+                          </TableCell>
+                          <TableCell className="font-medium">{notification.name}</TableCell>
+                          <TableCell>
+                            <Badge variant="outline">
+                              {notification.type === "email" ? "Email" : notification.type === "sms" ? "SMS" : "WhatsApp"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            {notification.triggerDays === 0
+                              ? "Día de vencimiento"
+                              : notification.triggerDays < 0
+                                ? `${Math.abs(notification.triggerDays)} días antes`
+                                : `${notification.triggerDays} días después`}
+                          </TableCell>
+                          <TableCell className="max-w-[300px] truncate">{notification.message}</TableCell>
+                          <TableCell>
+                            <Badge variant={notification.active ? "default" : "outline"}>
+                              {notification.active ? "Activo" : "Inactivo"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button variant="ghost" size="sm" onClick={() => openNotificationForm(notification)}>
+                              <Settings className="h-4 w-4 mr-1" /> Editar
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })
+                  )}
                 </TableBody>
               </Table>
             </CardContent>
             <CardFooter className="flex justify-between">
               <div className="text-sm text-muted-foreground">
-                Mostrando {rulesData.notificationRules.length} notificaciones configuradas
+                Mostrando {notificationRules.length} notificaciones configuradas
               </div>
               <Button variant="outline">
                 <Trash2 className="mr-2 h-4 w-4" /> Eliminar Seleccionadas
@@ -457,13 +358,21 @@ export function ConfiguracionReglas() {
                     <Label htmlFor="notification-name">Nombre</Label>
                     <Input
                       id="notification-name"
-                      defaultValue={editingNotification?.name || ""}
+                      value={notificationForm.name}
+                      onChange={(e) =>
+                        setNotificationForm({ ...notificationForm, name: e.target.value })
+                      }
                       placeholder="Ej: Recordatorio de pago"
                     />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="notification-type">Tipo</Label>
-                    <Select defaultValue={editingNotification?.type || "email"}>
+                    <Select
+                      value={notificationForm.type}
+                      onValueChange={(val) =>
+                        setNotificationForm({ ...notificationForm, type: val })
+                      }
+                    >
                       <SelectTrigger>
                         <SelectValue placeholder="Seleccione el tipo" />
                       </SelectTrigger>
@@ -481,7 +390,13 @@ export function ConfiguracionReglas() {
                     <Input
                       id="notification-days"
                       type="number"
-                      defaultValue={editingNotification?.triggerDays || 0}
+                      value={notificationForm.triggerDays}
+                      onChange={(e) =>
+                        setNotificationForm({
+                          ...notificationForm,
+                          triggerDays: Number(e.target.value),
+                        })
+                      }
                       placeholder="-3 (antes), 0 (día de), 5 (después)"
                     />
                     <p className="text-xs text-muted-foreground">
@@ -490,7 +405,15 @@ export function ConfiguracionReglas() {
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="notification-active">Estado</Label>
-                    <Select defaultValue={editingNotification?.active ? "active" : "inactive"}>
+                    <Select
+                      value={notificationForm.active ? 'active' : 'inactive'}
+                      onValueChange={(val) =>
+                        setNotificationForm({
+                          ...notificationForm,
+                          active: val === 'active',
+                        })
+                      }
+                    >
                       <SelectTrigger>
                         <SelectValue placeholder="Seleccione el estado" />
                       </SelectTrigger>
@@ -505,7 +428,10 @@ export function ConfiguracionReglas() {
                   <Label htmlFor="notification-message">Mensaje</Label>
                   <Input
                     id="notification-message"
-                    defaultValue={editingNotification?.message || ""}
+                    value={notificationForm.message}
+                    onChange={(e) =>
+                      setNotificationForm({ ...notificationForm, message: e.target.value })
+                    }
                     placeholder="Ingrese el mensaje de la notificación"
                   />
                   <p className="text-xs text-muted-foreground">
@@ -517,7 +443,9 @@ export function ConfiguracionReglas() {
                 <Button variant="outline" onClick={() => setShowNotificationForm(false)}>
                   Cancelar
                 </Button>
-                <Button>{editingNotification ? "Actualizar" : "Crear"} Notificación</Button>
+                <Button onClick={() => { if (editingNotification) { setNotificationRules(notificationRules.map((n) => n.id === editingNotification.id ? { ...notificationForm, id: n.id } : n)); } else { setNotificationRules([...notificationRules, { ...notificationForm, id: Date.now() }]); } setShowNotificationForm(false); }}>
+                  {editingNotification ? "Actualizar" : "Crear"} Notificación
+                </Button>
               </CardFooter>
             </Card>
           )}
@@ -542,25 +470,35 @@ export function ConfiguracionReglas() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {rulesData.blockingRules.map((rule) => (
-                    <TableRow key={rule.id}>
-                      <TableCell className="font-medium">{rule.name}</TableCell>
-                      <TableCell>{rule.description}</TableCell>
-                      <TableCell>{rule.daysAfterDue}</TableCell>
-                      <TableCell>
-                        <div className="flex flex-wrap gap-1">
-                          {rule.services.map((service, index) => (
-                            <Badge key={index} variant="outline">
-                              {service === "plataforma"
-                                ? "Plataforma"
-                                : service === "evaluaciones"
-                                  ? "Evaluaciones"
-                                  : service === "materiales"
-                                    ? "Materiales"
-                                    : service}
-                            </Badge>
-                          ))}
-                        </div>
+                  {blockingRules.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6} className="text-center">
+                        Sin datos
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    blockingRules.map((rule) => {
+                      return (
+                        <TableRow key={rule.id}>
+                        <TableCell className="font-medium">{rule.name}</TableCell>
+                        <TableCell>{rule.description}</TableCell>
+                        <TableCell>{rule.daysAfterDue}</TableCell>
+                        <TableCell>
+                          <div className="flex flex-wrap gap-1">
+                            {rule.services.map((service, index) => {
+                              return (
+                                <Badge key={index} variant="outline">
+                                  {service === "plataforma"
+                                    ? "Plataforma"
+                                    : service === "evaluaciones"
+                                      ? "Evaluaciones"
+                                      : service === "materiales"
+                                        ? "Materiales"
+                                        : service}
+                                </Badge>
+                              )
+                            })}
+                          </div>
                       </TableCell>
                       <TableCell>
                         <Badge variant={rule.active ? "default" : "outline"}>
@@ -572,9 +510,10 @@ export function ConfiguracionReglas() {
                           <Settings className="h-4 w-4 mr-1" /> Editar
                         </Button>
                       </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
+                        </TableRow>
+                      )
+                      }))}
+                  </TableBody>
               </Table>
             </CardContent>
             <CardFooter>
@@ -605,8 +544,16 @@ export function ConfiguracionReglas() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {rulesData.paymentGateways.map((gateway) => (
-                    <TableRow key={gateway.id}>
+                  {paymentGateways.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center">
+                        Sin datos
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    paymentGateways.map((gateway) => {
+                      return (
+                        <TableRow key={gateway.id}>
                       <TableCell className="font-medium">{gateway.name}</TableCell>
                       <TableCell>{gateway.description}</TableCell>
                       <TableCell>{gateway.fee}%</TableCell>
@@ -622,8 +569,9 @@ export function ConfiguracionReglas() {
                           <Settings className="h-4 w-4 mr-1" /> Configurar
                         </Button>
                       </TableCell>
-                    </TableRow>
-                  ))}
+                        </TableRow>
+                      )
+                      }))}
                 </TableBody>
               </Table>
             </CardContent>
@@ -655,8 +603,16 @@ export function ConfiguracionReglas() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {rulesData.exceptionCategories.map((category) => (
-                    <TableRow key={category.id}>
+                  {exceptionCategories.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center">
+                        Sin datos
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    exceptionCategories.map((category) => {
+                      return (
+                        <TableRow key={category.id}>
                       <TableCell className="font-medium">{category.name}</TableCell>
                       <TableCell>{category.description}</TableCell>
                       <TableCell>
@@ -691,9 +647,10 @@ export function ConfiguracionReglas() {
                         <Button variant="ghost" size="sm">
                           <Settings className="h-4 w-4 mr-1" /> Editar
                         </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                        </TableCell>
+                      </TableRow>
+                      )
+                      }))}
                 </TableBody>
               </Table>
             </CardContent>
@@ -708,4 +665,3 @@ export function ConfiguracionReglas() {
     </div>
   )
 }
-

--- a/components/finanzas/dashboard-financiero.tsx
+++ b/components/finanzas/dashboard-financiero.tsx
@@ -9,33 +9,16 @@ import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { fetchDashboardSummary, type DashboardSummary } from "@/services/finance"
+import {
+  fetchDashboardSummary,
+  type DashboardSummary,
+  fetchRecentPayments,
+  getKardexPagos,
+} from "@/services/finance"
 import { toast } from "@/hooks/use-toast"
 
-// Datos de ejemplo para el dashboard financiero
-const staticData = {
-  morosidadPorPrograma: [
-    { programa: "Desarrollo Web", porcentaje: 8.2 },
-    { programa: "Diseño UX/UI", porcentaje: 10.5 },
-    { programa: "Medicina", porcentaje: 15.3 },
-    { programa: "Psicología", porcentaje: 12.8 },
-    { programa: "Administración", porcentaje: 9.7 },
-  ],
-  pagosRecientes: [
-    { id: "pago-001", estudiante: "Juan Pérez", monto: 750, fecha: "10/03/2025", concepto: "Mensualidad Marzo" },
-    { id: "pago-002", estudiante: "María López", monto: 750, fecha: "09/03/2025", concepto: "Mensualidad Marzo" },
-    { id: "pago-003", estudiante: "Carlos Rodríguez", monto: 750, fecha: "08/03/2025", concepto: "Mensualidad Marzo" },
-    { id: "pago-004", estudiante: "Ana Martínez", monto: 750, fecha: "07/03/2025", concepto: "Mensualidad Marzo" },
-    { id: "pago-005", estudiante: "Roberto Gómez", monto: 750, fecha: "06/03/2025", concepto: "Mensualidad Marzo" },
-  ],
-  alertasMorosidad: [
-    { id: "alerta-001", estudiante: "Pedro Díaz", diasVencidos: 45, montoVencido: 1500, programa: "Medicina" },
-    { id: "alerta-002", estudiante: "Sofía Hernández", diasVencidos: 38, montoVencido: 1500, programa: "Psicología" },
-    { id: "alerta-003", estudiante: "Luis Torres", diasVencidos: 30, montoVencido: 750, programa: "Desarrollo Web" },
-    { id: "alerta-004", estudiante: "Carmen Jiménez", diasVencidos: 25, montoVencido: 750, programa: "Diseño UX/UI" },
-    { id: "alerta-005", estudiante: "Javier Morales", diasVencidos: 20, montoVencido: 750, programa: "Administración" },
-  ],
-}
+// Datos obtenidos de la API. Se inicializan vacíos para evitar mostrar datos de ejemplo
+const emptyArray: any[] = []
 
 export function DashboardFinanciero() {
   const [dateRange, setDateRange] = useState({
@@ -43,16 +26,24 @@ export function DashboardFinanciero() {
     to: new Date(),
   })
   const [summary, setSummary] = useState<DashboardSummary | null>(null)
+  const [recentPayments, setRecentPayments] = useState<any[]>([])
+  const [morosidadPorPrograma, setMorosidadPorPrograma] = useState<any[]>(emptyArray)
+  const [alertasMorosidad, setAlertasMorosidad] = useState<any[]>(emptyArray)
 
   useEffect(() => {
-    fetchDashboardSummary()
-      .then(setSummary)
+    Promise.all([fetchDashboardSummary(), fetchRecentPayments(), getKardexPagos()])
+      .then(([sum, payments, kardex]) => {
+        setSummary(sum)
+        setRecentPayments(payments)
+        if (Array.isArray(kardex)) {
+          setAlertasMorosidad(kardex.slice(0, 5))
+        }
+      })
       .catch(() =>
         toast({
           title: 'Error',
           description: 'No se pudo cargar el resumen financiero',
-        }),
-      )
+        }))
   }, [])
 
   // Función para calcular el cambio porcentual
@@ -224,15 +215,19 @@ export function DashboardFinanciero() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              {staticData.morosidadPorPrograma.map((item) => (
-                <div key={item.programa} className="space-y-1">
-                  <div className="flex justify-between text-sm">
-                    <span>{item.programa}</span>
-                    <span className="font-medium">{item.porcentaje}%</span>
+              {morosidadPorPrograma.length === 0 ? (
+                <div className="text-muted-foreground text-sm">Sin datos</div>
+              ) : (
+                morosidadPorPrograma.map((item) => (
+                  <div key={item.programa} className="space-y-1">
+                    <div className="flex justify-between text-sm">
+                      <span>{item.programa}</span>
+                      <span className="font-medium">{item.porcentaje}%</span>
+                    </div>
+                    <Progress value={item.porcentaje} max={20} className="h-2" />
                   </div>
-                  <Progress value={item.porcentaje} max={20} className="h-2" />
-                </div>
-              ))}
+                ))
+              )}
             </div>
           </CardContent>
         </Card>
@@ -255,14 +250,26 @@ export function DashboardFinanciero() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {staticData.pagosRecientes.map((pago) => (
-                  <TableRow key={pago.id}>
-                    <TableCell className="font-medium">{pago.estudiante}</TableCell>
-                    <TableCell>{pago.concepto}</TableCell>
-                    <TableCell>{pago.fecha}</TableCell>
-                    <TableCell className="text-right">Q{pago.monto.toLocaleString()}</TableCell>
+                {recentPayments.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center">
+                      Sin datos
+                    </TableCell>
                   </TableRow>
-                ))}
+                ) : (
+                  recentPayments.map((pago) => (
+                    <TableRow key={pago.id}>
+                      <TableCell className="font-medium">{pago.estudiante ?? pago.prospecto?.nombre_completo}</TableCell>
+                      <TableCell>{pago.concepto || pago.concept}</TableCell>
+                      <TableCell>
+                        {new Date(pago.fecha || pago.created_at).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        Q{Number(pago.monto || pago.amount).toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
               </TableBody>
             </Table>
           </CardContent>
@@ -289,18 +296,29 @@ export function DashboardFinanciero() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {staticData.alertasMorosidad.map((alerta) => (
-                  <TableRow key={alerta.id}>
-                    <TableCell className="font-medium">{alerta.estudiante}</TableCell>
-                    <TableCell>{alerta.programa}</TableCell>
-                    <TableCell>
-                      <Badge variant={alerta.diasVencidos > 30 ? "destructive" : "outline"} className="text-xs">
-                        {alerta.diasVencidos} días
-                      </Badge>
+                {alertasMorosidad.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center">
+                      Sin datos
                     </TableCell>
-                    <TableCell className="text-right text-red-500">Q{alerta.montoVencido.toLocaleString()}</TableCell>
                   </TableRow>
-                ))}
+                ) : (
+                  alertasMorosidad.map((alerta) => (
+                    <TableRow key={alerta.id}>
+                      <TableCell className="font-medium">{alerta.estudiante}</TableCell>
+                      <TableCell>{alerta.programa}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={alerta.diasVencidos > 30 ? "destructive" : "outline"}
+                          className="text-xs"
+                        >
+                          {alerta.diasVencidos} días
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right text-red-500">Q{alerta.montoVencido.toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))
+                )}
               </TableBody>
             </Table>
           </CardContent>

--- a/components/finanzas/dashboard-finanzas.tsx
+++ b/components/finanzas/dashboard-finanzas.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -10,73 +10,9 @@ import { BarChart, DollarSign, Users, AlertTriangle, Calendar, ArrowUpRight, Dow
 import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { fetchDashboardSummary, fetchRecentPayments, type DashboardSummary } from "@/services/finance"
+import { toast } from "@/hooks/use-toast"
 
-// Datos de ejemplo para las gráficas y tablas
-const financialData = {
-  totalIncome: 125000,
-  pendingPayments: 45000,
-  totalStudents: 350,
-  studentsOnTime: 280,
-  studentsLate: 70,
-  collectionRate: 73.5,
-  promiseRate: 65.2,
-  buckets: {
-    b1: 32, // 0-5 días
-    b2: 18, // 6-10 días
-    b3: 12, // 11-30 días
-    b4: 8, // +30 días
-  },
-  recentTransactions: [
-    {
-      id: "TRX-001",
-      student: "Carlos Méndez",
-      amount: 1400,
-      date: "2025-03-10",
-      method: "Tarjeta",
-      status: "completado",
-    },
-    {
-      id: "TRX-002",
-      student: "Ana Lucía Gómez",
-      amount: 1400,
-      date: "2025-03-09",
-      method: "Depósito",
-      status: "pendiente",
-    },
-    {
-      id: "TRX-003",
-      student: "Roberto Juárez",
-      amount: 2000,
-      date: "2025-03-09",
-      method: "Transferencia",
-      status: "completado",
-    },
-    {
-      id: "TRX-004",
-      student: "María Fernanda López",
-      amount: 1400,
-      date: "2025-03-08",
-      method: "Tarjeta",
-      status: "completado",
-    },
-    {
-      id: "TRX-005",
-      student: "Juan Pablo Herrera",
-      amount: 1400,
-      date: "2025-03-07",
-      method: "Depósito",
-      status: "rechazado",
-    },
-  ],
-  monthlyIncome: [
-    { month: "Ene", amount: 110000 },
-    { month: "Feb", amount: 115000 },
-    { month: "Mar", amount: 125000 },
-    { month: "Abr", amount: 0 }, // Proyección
-    { month: "May", amount: 0 }, // Proyección
-    { month: "Jun", amount: 0 }, // Proyección
-  ],
-}
 
 export function DashboardFinanzas() {
   const [dateRange, setDateRange] = useState({
@@ -85,6 +21,19 @@ export function DashboardFinanzas() {
   })
 
   const [activeTab, setActiveTab] = useState("overview")
+  const [summary, setSummary] = useState<DashboardSummary | null>(null)
+  const [recentTransactions, setRecentTransactions] = useState<any[]>([])
+
+  useEffect(() => {
+    Promise.all([fetchDashboardSummary(), fetchRecentPayments()])
+      .then(([sum, payments]) => {
+        setSummary(sum)
+        setRecentTransactions(payments)
+      })
+      .catch(() =>
+        toast({ title: "Error", description: "No se pudieron cargar los datos" })
+      )
+  }, [])
 
   return (
     <div className="space-y-6">
@@ -121,7 +70,7 @@ export function DashboardFinanzas() {
                 <DollarSign className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">Q{financialData.totalIncome.toLocaleString()}</div>
+                <div className="text-2xl font-bold">Q{(summary?.ingresosMensuales ?? 0).toLocaleString()}</div>
                 <p className="text-xs text-muted-foreground">+12% respecto al mes anterior</p>
               </CardContent>
             </Card>
@@ -131,11 +80,11 @@ export function DashboardFinanzas() {
                 <AlertTriangle className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">Q{financialData.pendingPayments.toLocaleString()}</div>
+                <div className="text-2xl font-bold">Q{(summary?.recaudacionPendiente ?? 0).toLocaleString()}</div>
                 <p className="text-xs text-muted-foreground">
-                  {Math.round(
-                    (financialData.pendingPayments / (financialData.totalIncome + financialData.pendingPayments)) * 100,
-                  )}
+                  {summary && summary.ingresosMensuales + summary.recaudacionPendiente > 0
+                    ? Math.round((summary.recaudacionPendiente / (summary.ingresosMensuales + summary.recaudacionPendiente)) * 100)
+                    : 0}
                   % del total facturado
                 </p>
               </CardContent>
@@ -146,18 +95,11 @@ export function DashboardFinanzas() {
                 <Users className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
-                  {financialData.studentsOnTime} / {financialData.totalStudents}
-                </div>
+                <div className="text-2xl font-bold">{summary?.estudiantesActivos ?? 0}</div>
                 <div className="mt-2">
-                  <Progress
-                    value={Math.round((financialData.studentsOnTime / financialData.totalStudents) * 100)}
-                    className="h-2"
-                  />
+                  <Progress value={100} className="h-2" />
                 </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {Math.round((financialData.studentsOnTime / financialData.totalStudents) * 100)}% de alumnos sin mora
-                </p>
+                <p className="text-xs text-muted-foreground mt-1">Estudiantes activos</p>
               </CardContent>
             </Card>
             <Card>
@@ -166,12 +108,12 @@ export function DashboardFinanzas() {
                 <BarChart className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">{financialData.collectionRate}%</div>
+                <div className="text-2xl font-bold">{summary?.tasaMorosidad ?? 0}%</div>
                 <div className="flex items-center gap-1 mt-1">
-                  <span className="text-xs text-green-600">+2.5%</span>
+                  <span className="text-xs text-green-600">+0%</span>
                   <ArrowUpRight className="h-3 w-3 text-green-600" />
                 </div>
-                <p className="text-xs text-muted-foreground">KPR (Promesa de pago): {financialData.promiseRate}%</p>
+                <p className="text-xs text-muted-foreground">KPR (Promesa de pago): 0%</p>
               </CardContent>
             </Card>
           </div>
@@ -185,21 +127,8 @@ export function DashboardFinanzas() {
                 <CardDescription>Comparativa de ingresos por mes</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="h-[300px] flex items-end gap-2">
-                  {financialData.monthlyIncome.map((month) => (
-                    <div key={month.month} className="relative flex flex-col items-center">
-                      <div
-                        className={`w-12 rounded-t-md ${month.amount > 0 ? "bg-blue-500" : "bg-gray-200"}`}
-                        style={{
-                          height: `${month.amount > 0 ? (month.amount / 125000) * 250 : 100}px`,
-                        }}
-                      ></div>
-                      <div className="absolute -top-6 text-xs font-medium">
-                        {month.amount > 0 ? `Q${(month.amount / 1000).toFixed(0)}K` : ""}
-                      </div>
-                      <div className="mt-2 text-xs">{month.month}</div>
-                    </div>
-                  ))}
+                <div className="h-[300px] flex items-center justify-center text-sm text-muted-foreground">
+                  Sin datos
                 </div>
               </CardContent>
             </Card>
@@ -211,67 +140,8 @@ export function DashboardFinanzas() {
                 <CardDescription>Distribución de alumnos por días de atraso</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="bg-blue-50">
-                          B1
-                        </Badge>
-                        <span className="text-sm">0-5 días</span>
-                      </div>
-                      <span className="text-sm font-medium">{financialData.buckets.b1} alumnos</span>
-                    </div>
-                    <Progress
-                      value={(financialData.buckets.b1 / financialData.studentsLate) * 100}
-                      className="h-2 bg-blue-100"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="bg-yellow-50">
-                          B2
-                        </Badge>
-                        <span className="text-sm">6-10 días</span>
-                      </div>
-                      <span className="text-sm font-medium">{financialData.buckets.b2} alumnos</span>
-                    </div>
-                    <Progress
-                      value={(financialData.buckets.b2 / financialData.studentsLate) * 100}
-                      className="h-2 bg-yellow-100"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="bg-orange-50">
-                          B3
-                        </Badge>
-                        <span className="text-sm">11-30 días</span>
-                      </div>
-                      <span className="text-sm font-medium">{financialData.buckets.b3} alumnos</span>
-                    </div>
-                    <Progress
-                      value={(financialData.buckets.b3 / financialData.studentsLate) * 100}
-                      className="h-2 bg-orange-100"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="bg-red-50">
-                          B4
-                        </Badge>
-                        <span className="text-sm">+30 días</span>
-                      </div>
-                      <span className="text-sm font-medium">{financialData.buckets.b4} alumnos</span>
-                    </div>
-                    <Progress
-                      value={(financialData.buckets.b4 / financialData.studentsLate) * 100}
-                      className="h-2 bg-red-100"
-                    />
-                  </div>
+                <div className="h-[150px] flex items-center justify-center text-sm text-muted-foreground">
+                  Sin datos
                 </div>
               </CardContent>
               <CardFooter>
@@ -301,32 +171,42 @@ export function DashboardFinanzas() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {financialData.recentTransactions.map((transaction) => (
-                    <TableRow key={transaction.id}>
-                      <TableCell className="font-medium">{transaction.id}</TableCell>
-                      <TableCell>{transaction.student}</TableCell>
-                      <TableCell>Q{transaction.amount.toLocaleString()}</TableCell>
-                      <TableCell>{new Date(transaction.date).toLocaleDateString()}</TableCell>
-                      <TableCell>{transaction.method}</TableCell>
-                      <TableCell>
-                        <Badge
-                          variant={
-                            transaction.status === "completado"
-                              ? "default"
-                              : transaction.status === "pendiente"
-                                ? "outline"
-                                : "destructive"
-                          }
-                        >
-                          {transaction.status === "completado"
-                            ? "Completado"
-                            : transaction.status === "pendiente"
-                              ? "Pendiente"
-                              : "Rechazado"}
-                        </Badge>
+                  {recentTransactions.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6} className="text-center">
+                        Sin datos
                       </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    recentTransactions.map((transaction) => (
+                      <TableRow key={transaction.id}>
+                        <TableCell className="font-medium">{transaction.id}</TableCell>
+                        <TableCell>
+                          {transaction.estudiante ?? transaction.prospecto?.nombre_completo}
+                        </TableCell>
+                        <TableCell>Q{Number(transaction.monto || transaction.amount).toLocaleString()}</TableCell>
+                        <TableCell>{new Date(transaction.fecha || transaction.created_at).toLocaleDateString()}</TableCell>
+                        <TableCell>{transaction.metodo || transaction.method}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              transaction.status === "completado"
+                                ? "default"
+                                : transaction.status === "pendiente"
+                                  ? "outline"
+                                  : "destructive"
+                            }
+                          >
+                            {transaction.status === "completado"
+                              ? "Completado"
+                              : transaction.status === "pendiente"
+                                ? "Pendiente"
+                                : "Rechazado"}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>

--- a/components/finanzas/subir-boleta.tsx
+++ b/components/finanzas/subir-boleta.tsx
@@ -22,55 +22,17 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Separator } from "@/components/ui/separator"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { getPendingReconciliation } from "@/services/finance"
+import { fetchProspectos } from "@/services/prospectos"
 
-// Datos de ejemplo para la carga de boletas
-const boletaData = {
-  banks: [
-    { id: "bank-001", name: "Banco Industrial" },
-    { id: "bank-002", name: "Banrural" },
-    { id: "bank-003", name: "Banco G&T" },
-    { id: "bank-004", name: "BAC Credomatic" },
-    { id: "bank-005", name: "Banco Promerica" },
-  ],
-  students: [
-    { id: "est-001", name: "Juan Pérez", carnet: "2025-0123", program: "Desarrollo Web Full Stack" },
-    { id: "est-002", name: "María López", carnet: "2025-0124", program: "Diseño UX/UI" },
-    { id: "est-003", name: "Carlos Rodríguez", carnet: "2025-0125", program: "Data Science" },
-    { id: "est-004", name: "Ana Martínez", carnet: "2025-0126", program: "Desarrollo Web Full Stack" },
-    { id: "est-005", name: "Roberto Gómez", carnet: "2024-0987", program: "Ciberseguridad" },
-  ],
-  recentUploads: [
-    {
-      id: "upload-001",
-      studentName: "Juan Pérez",
-      studentId: "2025-0123",
-      bank: "Banco Industrial",
-      receiptNumber: "BI-123456",
-      amount: 750,
-      date: "2025-03-10",
-      authNumber: "AUTH-987654",
-      status: "pendiente",
-      uploadDate: "2025-03-10",
-    },
-    {
-      id: "upload-002",
-      studentName: "María López",
-      studentId: "2025-0124",
-      bank: "Banrural",
-      receiptNumber: "BR-654321",
-      amount: 750,
-      date: "2025-03-09",
-      authNumber: "AUTH-123456",
-      status: "conciliado",
-      uploadDate: "2025-03-09",
-    },
-  ],
-}
 
 export function SubirBoleta() {
   const [activeTab, setActiveTab] = useState("upload-receipt")
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedStudent, setSelectedStudent] = useState<any | null>(null)
+  const [banks, setBanks] = useState<any[]>([])
+  const [students, setStudents] = useState<any[]>([])
+  const [recentUploads, setRecentUploads] = useState<any[]>([])
   const [uploadProgress, setUploadProgress] = useState(0)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadForm, setUploadForm] = useState({
@@ -82,13 +44,29 @@ export function SubirBoleta() {
     notes: "",
   })
 
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getPendingReconciliation()
+        if (data) {
+          setBanks(data.banks || [])
+          setRecentUploads(data.reconciliationHistory || [])
+        }
+        const ps = await fetchProspectos()
+        setStudents(ps)
+      } catch (e) {
+        // ignore errors for now
+      }
+    }
+    load()
+  }, [])
+
   // Función para buscar estudiante
   const handleSearchStudent = () => {
-    // Simulación de búsqueda - En producción, esto sería una llamada a API
-    const foundStudent = boletaData.students.find(
+    const foundStudent = students.find(
       (student) =>
-        student.carnet.toLowerCase() === searchQuery.toLowerCase() ||
-        student.name.toLowerCase().includes(searchQuery.toLowerCase()),
+        student.carnet?.toLowerCase() === searchQuery.toLowerCase() ||
+        student.name?.toLowerCase().includes(searchQuery.toLowerCase()),
     )
 
     setSelectedStudent(foundStudent || null)
@@ -215,7 +193,7 @@ export function SubirBoleta() {
                       <SelectValue placeholder="Seleccione el banco" />
                     </SelectTrigger>
                     <SelectContent>
-                      {boletaData.banks.map((bank) => (
+                      {banks.map((bank) => (
                         <SelectItem key={bank.id} value={bank.id}>
                           {bank.name}
                         </SelectItem>
@@ -328,9 +306,9 @@ export function SubirBoleta() {
               <CardDescription>Boletas cargadas recientemente por usted</CardDescription>
             </CardHeader>
             <CardContent>
-              {boletaData.recentUploads.length > 0 ? (
+              {recentUploads.length > 0 ? (
                 <div className="space-y-4">
-                  {boletaData.recentUploads.map((upload) => (
+                  {recentUploads.map((upload) => (
                     <div key={upload.id} className="border rounded-md p-4">
                       <div className="flex justify-between items-start mb-2">
                         <div>

--- a/services/finance.ts
+++ b/services/finance.ts
@@ -41,6 +41,12 @@ export const getPayments = async (params?: any) => {
   return res.data
 }
 
+export const fetchRecentPayments = async (limit = 5) => {
+  const res = await api.get('/payments', { params: { per_page: limit } })
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return Array.isArray(data) ? data.slice(0, limit) : []
+}
+
 export const createPayment = async (data: any) => {
   const res = await api.post('/payments', data)
   return res.data
@@ -51,8 +57,11 @@ export const getPaymentRules = async () => {
   return res.data
 }
 
-export const updatePaymentRules = async (data: any) => {
-  const res = await api.put('/payment-rules', data)
+export const updatePaymentRules = async (
+  id: string | number,
+  data: any,
+) => {
+  const res = await api.put(`/payment-rules/${id}`, data)
   return res.data
 }
 
@@ -151,4 +160,35 @@ export const exportFinancialReport = async (
   })
   return res.data
 }
+
+export const getKardexPagos = async (params?: any) => {
+  const res = await api.get('/kardex-pagos', { params })
+  return res.data
+}
+
+export const createKardexPago = async (data: any) => {
+  const res = await api.post('/kardex-pagos', data)
+  return res.data
+}
+
+export const getCuotasByProspecto = async (
+  prospectoId: string | number,
+  params?: any,
+) => {
+  const res = await api.get(`/prospectos/${prospectoId}/cuotas`, {
+    params,
+  })
+  return res.data
+}
+
+export const getCuotasByPrograma = async (
+  programaId: string | number,
+  params?: any,
+) => {
+  const res = await api.get(`/estudiante-programa/${programaId}/cuotas`, {
+    params,
+  })
+  return res.data
+}
+
 


### PR DESCRIPTION
## Summary
- consume kardex payments in finance dashboard
- load all rule collections from backend
- allow adding/updating notification rules locally
- expose kardex API helpers
- add helpers to read quotas for prospects and programs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b301c30d08328b2678eafb08399ee