### PR TITLE
Update API base URL docs

### DIFF
--- a/utils/apiConfig.ts
+++ b/utils/apiConfig.ts
@@ -1,5 +1,10 @@
+// Base URL of the Laravel API server. Set `NEXT_PUBLIC_API_URL` in your
+// environment (for example in `.env.local`) to the host where the backend is
+// running **without** the `/api` suffix. The axios instance in `services/api.ts`
+// appends `/api` automatically.
+const envUrl = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8080';
+
 // Sanitize the base URL to avoid duplicating the `/api` segment when the
 // environment variable already includes it.
-const envUrl = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8080';
 export const API_BASE_URL = envUrl.replace(/\/api\/?$/, '');
 


### PR DESCRIPTION
## Summary
- document how NEXT_PUBLIC_API_URL should point to the Laravel API host

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx next lint` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_686b6413909c8328bcd6a92ee674759c