### PR TITLE
Hook up finance components with API

### DIFF
--- a/components/finanzas/estado-cuenta-estudiante.tsx
+++ b/components/finanzas/estado-cuenta-estudiante.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -31,77 +31,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-
-// Datos de ejemplo para el estado de cuenta
-const accountData = {
-  student: {
-    name: "Carlos Méndez",
-    id: "2023-0042",
-    program: "Ingeniería en Sistemas",
-    status: "Activo",
-  },
-  balance: {
-    currentDebt: 1400,
-    totalDebt: 2800,
-    nextDueDate: "2025-04-05",
-    daysUntilDue: 25,
-    latePayments: 1,
-    isBlocked: false,
-    warningLevel: 1, // 0: normal, 1: advertencia, 2: crítico
-  },
-  pendingPayments: [
-    {
-      id: "PAY-2025-03",
-      concept: "Cuota Mensual - Marzo 2025",
-      amount: 1400,
-      dueDate: "2025-03-05",
-      status: "vencido",
-      lateFee: 50,
-      daysLate: 15,
-    },
-    {
-      id: "PAY-2025-04",
-      concept: "Cuota Mensual - Abril 2025",
-      amount: 1400,
-      dueDate: "2025-04-05",
-      status: "pendiente",
-      lateFee: 0,
-      daysLate: 0,
-    },
-  ],
-  paymentHistory: [
-    {
-      id: "TRX-2025-02",
-      concept: "Cuota Mensual - Febrero 2025",
-      amount: 1400,
-      dueDate: "2025-02-05",
-      paymentDate: "2025-02-03",
-      method: "Tarjeta de Crédito",
-      reference: "TRX-78945612",
-      status: "completado",
-    },
-    {
-      id: "TRX-2025-01",
-      concept: "Cuota Mensual - Enero 2025",
-      amount: 1400,
-      dueDate: "2025-01-05",
-      paymentDate: "2025-01-04",
-      method: "Depósito Bancario",
-      reference: "DEP-12345678",
-      status: "completado",
-    },
-    {
-      id: "TRX-2024-12",
-      concept: "Cuota Mensual - Diciembre 2024",
-      amount: 1400,
-      dueDate: "2024-12-05",
-      paymentDate: "2024-12-02",
-      method: "Transferencia",
-      reference: "TRF-98765432",
-      status: "completado",
-    },
-  ],
-}
+import { fetchStudentAccountSummary } from "@/services/finance"
 
 export function EstadoCuentaEstudiante() {
   const [activeTab, setActiveTab] = useState("pending")
@@ -109,6 +39,22 @@ export function EstadoCuentaEstudiante() {
   const [showReceiptUpload, setShowReceiptUpload] = useState(false)
   const [selectedPayment, setSelectedPayment] = useState<any | null>(null)
   const [uploadFile, setUploadFile] = useState<File | null>(null)
+  const [accountData, setAccountData] = useState<any | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await fetchStudentAccountSummary()
+        setAccountData(data)
+      } catch (e) {
+        console.error('Error fetching account summary', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadData()
+  }, [])
 
   // Función para iniciar el pago con tarjeta
   const startCardPayment = (payment: any) => {
@@ -173,6 +119,14 @@ export function EstadoCuentaEstudiante() {
     return accountData.pendingPayments.reduce((total, payment) => {
       return total + payment.amount + payment.lateFee
     }, 0)
+  }
+
+  if (loading || !accountData) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <p>Cargando estado de cuenta...</p>
+      </div>
+    )
   }
 
   return (

--- a/components/finanzas/reportes-financieros.tsx
+++ b/components/finanzas/reportes-financieros.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -21,137 +21,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { exportFinancialReport } from "@/services/finance"
+import { exportFinancialReport, fetchFinancialReports } from "@/services/finance"
 
-// Datos de ejemplo para los reportes financieros
-const reportesData = {
-  estudiantes: [
-    {
-      id: "est-001",
-      nombre: "Juan Pérez",
-      carnet: "2023-0042",
-      programa: "Desarrollo Web Full Stack",
-      saldoPendiente: 1500,
-      ultimoPago: "15/02/2025",
-    },
-    {
-      id: "est-002",
-      nombre: "María López",
-      carnet: "2023-0078",
-      programa: "Diseño UX/UI",
-      saldoPendiente: 2500,
-      ultimoPago: "10/01/2025",
-    },
-    {
-      id: "est-003",
-      nombre: "Carlos Rodríguez",
-      carnet: "2023-0091",
-      programa: "Medicina",
-      saldoPendiente: 0,
-      ultimoPago: "05/03/2025",
-    },
-    {
-      id: "est-004",
-      nombre: "Ana Martínez",
-      carnet: "2023-0112",
-      programa: "Psicología",
-      saldoPendiente: 3000,
-      ultimoPago: "20/12/2024",
-    },
-    {
-      id: "est-005",
-      nombre: "Roberto Gómez",
-      carnet: "2023-0125",
-      programa: "Administración",
-      saldoPendiente: 750,
-      ultimoPago: "25/02/2025",
-    },
-  ],
-  librosContables: [
-    {
-      id: "libro-001",
-      nombre: "Libro Diario",
-      descripcion: "Registro cronológico de transacciones",
-      ultimaActualizacion: "01/03/2025",
-    },
-    {
-      id: "libro-002",
-      nombre: "Libro Mayor",
-      descripcion: "Resumen de cuentas y saldos",
-      ultimaActualizacion: "01/03/2025",
-    },
-    {
-      id: "libro-003",
-      nombre: "Balance General",
-      descripcion: "Estado financiero de activos y pasivos",
-      ultimaActualizacion: "29/02/2025",
-    },
-    {
-      id: "libro-004",
-      nombre: "Estado de Resultados",
-      descripcion: "Ingresos y gastos del período",
-      ultimaActualizacion: "29/02/2025",
-    },
-    {
-      id: "libro-005",
-      nombre: "Libro de Inventarios",
-      descripcion: "Registro de bienes y activos",
-      ultimaActualizacion: "15/02/2025",
-    },
-  ],
-  tiposReporte: [
-    { id: "rep-001", nombre: "Ingresos Mensuales", descripcion: "Reporte de ingresos por mes" },
-    { id: "rep-002", nombre: "Morosidad por Programa", descripcion: "Análisis de morosidad por programa académico" },
-    { id: "rep-003", nombre: "Proyección de Pagos", descripcion: "Proyección de pagos para los próximos 3 meses" },
-    { id: "rep-004", nombre: "Conciliaciones Bancarias", descripcion: "Resumen de conciliaciones bancarias" },
-    { id: "rep-005", nombre: "Becas y Descuentos", descripcion: "Impacto financiero de becas y descuentos" },
-  ],
-  transacciones: [
-    {
-      id: "trans-001",
-      fecha: "01/03/2025",
-      concepto: "Pago mensualidad",
-      estudiante: "Juan Pérez",
-      monto: 750,
-      tipo: "ingreso",
-    },
-    {
-      id: "trans-002",
-      fecha: "02/03/2025",
-      concepto: "Pago mensualidad",
-      estudiante: "María López",
-      monto: 750,
-      tipo: "ingreso",
-    },
-    {
-      id: "trans-003",
-      fecha: "02/03/2025",
-      concepto: "Pago matrícula",
-      estudiante: "Pedro Díaz",
-      monto: 1500,
-      tipo: "ingreso",
-    },
-    {
-      id: "trans-004",
-      fecha: "03/03/2025",
-      concepto: "Compra material didáctico",
-      estudiante: "",
-      monto: 5000,
-      tipo: "egreso",
-    },
-    {
-      id: "trans-005",
-      fecha: "05/03/2025",
-      concepto: "Pago mensualidad",
-      estudiante: "Carlos Rodríguez",
-      monto: 750,
-      tipo: "ingreso",
-    },
-  ],
-}
 
 // Componente para generar estados de cuenta
-const GeneradorEstadosCuenta = () => {
+const GeneradorEstadosCuenta = ({ data }: { data: any }) => {
   const [dateRange, setDateRange] = useState({
     from: new Date(new Date().setDate(new Date().getDate() - 30)),
     to: new Date(),
@@ -174,14 +48,14 @@ const GeneradorEstadosCuenta = () => {
   // Función para seleccionar todos los estudiantes
   const handleSelectAllStudents = (checked: boolean) => {
     if (checked) {
-      setSelectedStudents(reportesData.estudiantes.map((student) => student.id))
+      setSelectedStudents(data.estudiantes.map((student: any) => student.id))
     } else {
       setSelectedStudents([])
     }
   }
 
   // Función para filtrar estudiantes
-  const filteredStudents = reportesData.estudiantes.filter(
+  const filteredStudents = data.estudiantes.filter(
     (student) =>
       student.nombre.toLowerCase().includes(searchQuery.toLowerCase()) ||
       student.carnet.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -485,7 +359,7 @@ const GeneradorEstadosCuenta = () => {
 }
 
 // Componente para generar libros contables
-const GeneradorLibrosContables = () => {
+const GeneradorLibrosContables = ({ data }: { data: any }) => {
   const [dateRange, setDateRange] = useState({
     from: new Date(new Date().setDate(1)), // Primer día del mes actual
     to: new Date(),
@@ -507,7 +381,7 @@ const GeneradorLibrosContables = () => {
   // Función para seleccionar todos los libros
   const handleSelectAllBooks = (checked: boolean) => {
     if (checked) {
-      setSelectedBooks(reportesData.librosContables.map((book) => book.id))
+      setSelectedBooks(data.librosContables.map((book: any) => book.id))
     } else {
       setSelectedBooks([])
     }
@@ -569,8 +443,8 @@ const GeneradorLibrosContables = () => {
                   <Checkbox
                     id="select-all-books"
                     checked={
-                      selectedBooks.length === reportesData.librosContables.length &&
-                      reportesData.librosContables.length > 0
+                      selectedBooks.length === data.librosContables.length &&
+                      data.librosContables.length > 0
                     }
                     onCheckedChange={handleSelectAllBooks}
                   />
@@ -582,7 +456,7 @@ const GeneradorLibrosContables = () => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {reportesData.librosContables.map((book) => (
+              {data.librosContables.map((book: any) => (
                 <TableRow key={book.id}>
                   <TableCell>
                     <Checkbox
@@ -665,7 +539,7 @@ const GeneradorLibrosContables = () => {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {reportesData.transacciones.map((trans) => (
+                      {data.transacciones.map((trans: any) => (
                         <TableRow key={trans.id}>
                           <TableCell>{trans.fecha}</TableCell>
                           <TableCell>{trans.concepto}</TableCell>
@@ -971,6 +845,31 @@ const GeneradorLibrosContables = () => {
 }
 
 export function ReportesFinancieros() {
+  const [reportesData, setReportesData] = useState<any | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await fetchFinancialReports()
+        setReportesData(data)
+      } catch (e) {
+        console.error('Error fetching financial reports', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadData()
+  }, [])
+
+  if (loading || !reportesData) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <p>Cargando reportes...</p>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -995,11 +894,11 @@ export function ReportesFinancieros() {
         </TabsList>
 
         <TabsContent value="estados-cuenta">
-          <GeneradorEstadosCuenta />
+          <GeneradorEstadosCuenta data={reportesData} />
         </TabsContent>
 
         <TabsContent value="libros-contables">
-          <GeneradorLibrosContables />
+          <GeneradorLibrosContables data={reportesData} />
         </TabsContent>
 
         <TabsContent value="reportes-personalizados">
@@ -1011,7 +910,7 @@ export function ReportesFinancieros() {
               </CardHeader>
               <CardContent>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {reportesData.tiposReporte.map((reporte) => (
+                  {reportesData.tiposReporte.map((reporte: any) => (
                     <Card key={reporte.id} className="border border-muted">
                       <CardHeader className="pb-2">
                         <CardTitle className="text-base">{reporte.nombre}</CardTitle>

--- a/components/finanzas/seguimiento-cobros.tsx
+++ b/components/finanzas/seguimiento-cobros.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -37,187 +37,15 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { DatePickerWithRange } from "@/components/ui/date-range-picker"
 import { Separator } from "@/components/ui/separator"
-
-// Datos de ejemplo para el seguimiento de cobros
-const collectionData = {
-  pendingStudents: [
-    {
-      id: "2023-0042",
-      name: "Carlos Méndez",
-      program: "Ingeniería en Sistemas",
-      totalDebt: 2850,
-      lateMonths: 2,
-      latestDueDate: "2025-02-05",
-      daysLate: 45,
-      bucket: "B3", // B1: 0-5 días, B2: 6-10 días, B3: 11-30 días, B4: +30 días
-      status: "bloqueado",
-      lastContact: "2025-03-01",
-      promiseDate: "2025-03-15",
-      score: 85,
-      contactHistory: [
-        { date: "2025-03-01", type: "llamada", notes: "Promete pagar el 15 de marzo", agent: "María López" },
-        { date: "2025-02-20", type: "email", notes: "Se envió recordatorio de pago", agent: "Sistema" },
-        { date: "2025-02-10", type: "sms", notes: "Se envió notificación de vencimiento", agent: "Sistema" },
-      ],
-    },
-    {
-      id: "2023-0078",
-      name: "Ana Lucía Gómez",
-      program: "Administración de Empresas",
-      totalDebt: 1450,
-      lateMonths: 1,
-      latestDueDate: "2025-03-05",
-      daysLate: 15,
-      bucket: "B3",
-      status: "activo",
-      lastContact: "2025-03-08",
-      promiseDate: "2025-03-20",
-      score: 72,
-      contactHistory: [
-        {
-          date: "2025-03-08",
-          type: "llamada",
-          notes: "Indica que realizará el pago el 20 de marzo",
-          agent: "Juan Pérez",
-        },
-        { date: "2025-03-06", type: "email", notes: "Se envió recordatorio de pago", agent: "Sistema" },
-      ],
-    },
-    {
-      id: "2023-0103",
-      name: "Roberto Juárez",
-      program: "Diseño Gráfico",
-      totalDebt: 4200,
-      lateMonths: 3,
-      latestDueDate: "2025-01-05",
-      daysLate: 75,
-      bucket: "B4",
-      status: "bloqueado",
-      lastContact: "2025-03-05",
-      promiseDate: null,
-      score: 92,
-      contactHistory: [
-        { date: "2025-03-05", type: "llamada", notes: "No contesta", agent: "María López" },
-        { date: "2025-02-25", type: "llamada", notes: "Número fuera de servicio", agent: "Juan Pérez" },
-        { date: "2025-02-15", type: "email", notes: "Se envió notificación de bloqueo", agent: "Sistema" },
-        { date: "2025-02-05", type: "sms", notes: "Se envió recordatorio de pago", agent: "Sistema" },
-      ],
-    },
-    {
-      id: "2023-0056",
-      name: "María Fernanda López",
-      program: "Psicología",
-      totalDebt: 1400,
-      lateMonths: 1,
-      latestDueDate: "2025-03-05",
-      daysLate: 5,
-      bucket: "B1",
-      status: "activo",
-      lastContact: null,
-      promiseDate: null,
-      score: 65,
-      contactHistory: [],
-    },
-    {
-      id: "2023-0091",
-      name: "Juan Pablo Herrera",
-      program: "Medicina",
-      totalDebt: 1450,
-      lateMonths: 1,
-      latestDueDate: "2025-03-05",
-      daysLate: 8,
-      bucket: "B2",
-      status: "activo",
-      lastContact: "2025-03-10",
-      promiseDate: "2025-03-13",
-      score: 78,
-      contactHistory: [
-        {
-          date: "2025-03-10",
-          type: "llamada",
-          notes: "Indica que realizará el pago el 13 de marzo",
-          agent: "María López",
-        },
-      ],
-    },
-  ],
-  promisesCalendar: [
-    {
-      id: "prom-001",
-      studentId: "2023-0042",
-      studentName: "Carlos Méndez",
-      promiseDate: "2025-03-15",
-      amount: 2850,
-      status: "pendiente",
-      notes: "Prometió pagar después de recibir su sueldo",
-    },
-    {
-      id: "prom-002",
-      studentId: "2023-0078",
-      studentName: "Ana Lucía Gómez",
-      promiseDate: "2025-03-20",
-      amount: 1450,
-      status: "pendiente",
-      notes: "Esperando transferencia de sus padres",
-    },
-    {
-      id: "prom-003",
-      studentId: "2023-0091",
-      studentName: "Juan Pablo Herrera",
-      promiseDate: "2025-03-13",
-      amount: 1450,
-      status: "pendiente",
-      notes: "Pagará con tarjeta de crédito",
-    },
-    {
-      id: "prom-004",
-      studentId: "2023-0112",
-      studentName: "Lucía Ramírez",
-      promiseDate: "2025-03-12",
-      amount: 1400,
-      status: "cumplida",
-      notes: "Pagó en efectivo en oficina central",
-    },
-    {
-      id: "prom-005",
-      studentId: "2023-0098",
-      studentName: "Pedro Alvarado",
-      promiseDate: "2025-03-10",
-      amount: 1400,
-      status: "incumplida",
-      notes: "No realizó el pago en la fecha acordada",
-    },
-  ],
-  messageTemplates: [
-    {
-      id: "tmpl-001",
-      name: "Recordatorio de promesa",
-      type: "sms",
-      content:
-        "Estimado/a {nombre}, le recordamos que tiene un compromiso de pago para el día {fecha_promesa} por Q{monto}. Gracias.",
-    },
-    {
-      id: "tmpl-002",
-      name: "Seguimiento de mora",
-      type: "email",
-      content:
-        "Estimado/a {nombre}, su cuenta presenta un atraso de {dias_mora} días. Por favor, regularice su situación lo antes posible para evitar recargos adicionales.",
-    },
-    {
-      id: "tmpl-003",
-      name: "Aviso de bloqueo",
-      type: "sms",
-      content:
-        "Estimado/a {nombre}, su cuenta será bloqueada en 5 días si no realiza el pago pendiente de Q{monto}. Contáctenos para resolver su situación.",
-    },
-  ],
-}
+import { fetchCollectionData } from "@/services/finance"
 
 export function SeguimientoCobros() {
   const [activeTab, setActiveTab] = useState("pending-students")
   const [showContactDialog, setShowContactDialog] = useState(false)
   const [showMessageDialog, setShowMessageDialog] = useState(false)
   const [showPromiseDialog, setShowPromiseDialog] = useState(false)
+  const [collectionData, setCollectionData] = useState<any | null>(null)
+  const [loading, setLoading] = useState(true)
   const [selectedStudent, setSelectedStudent] = useState<any | null>(null)
   const [selectedPromise, setSelectedPromise] = useState<any | null>(null)
   const [contactType, setContactType] = useState<string>("llamada")
@@ -229,6 +57,20 @@ export function SeguimientoCobros() {
     from: new Date(),
     to: new Date(new Date().setDate(new Date().getDate() + 7)),
   })
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await fetchCollectionData()
+        setCollectionData(data)
+      } catch (e) {
+        console.error('Error fetching collection data', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadData()
+  }, [])
 
   // Función para abrir el diálogo de contacto
   const openContactDialog = (student: any) => {
@@ -256,7 +98,7 @@ export function SeguimientoCobros() {
   // Función para manejar la selección de plantilla
   const handleTemplateChange = (templateId: string) => {
     setSelectedTemplate(templateId)
-    const template = collectionData.messageTemplates.find((t) => t.id === templateId)
+    const template = collectionData?.messageTemplates.find((t) => t.id === templateId)
     if (template && selectedStudent) {
       let content = template.content
         .replace("{nombre}", selectedStudent.name)
@@ -335,6 +177,14 @@ export function SeguimientoCobros() {
       default:
         return <MessageSquare className="h-4 w-4" />
     }
+  }
+
+  if (loading || !collectionData) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <p>Cargando datos...</p>
+      </div>
+    )
   }
 
   return (

--- a/services/finance.ts
+++ b/services/finance.ts
@@ -192,4 +192,24 @@ export const getCuotasByPrograma = async (
   return res.data
 }
 
+export const fetchCollectionData = async (params?: any) => {
+  const res = await api.get('/finance/collections', { params })
+  return res.data
+}
+
+export const fetchStudentAccountSummary = async (
+  studentId?: string | number,
+) => {
+  const url = studentId
+    ? `/students/${studentId}/account-summary`
+    : '/students/account-summary'
+  const res = await api.get(url)
+  return res.data
+}
+
+export const fetchFinancialReports = async (params?: any) => {
+  const res = await api.get('/financial-reports', { params })
+  return res.data
+}
+
 


### PR DESCRIPTION
## Summary
- fetch collection data, student account summaries and financial reports from API
- replace mock data in finance components
- show loading placeholders while waiting for data

## Testing
- `npm run lint` *(fails: next not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b6409298c8328aab417cb73d1b6f8