### PR TITLE
Improve bulk course assignment view

### DIFF
--- a/app/academico/asignacion/loading.tsx
+++ b/app/academico/asignacion/loading.tsx
@@ -1,4 +1,8 @@
 export default function Loading() {
-  return null
+  return (
+    <div className="flex items-center justify-center h-96">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+    </div>
+  )
 }
 

--- a/app/academico/asignacion/simple/page.tsx
+++ b/app/academico/asignacion/simple/page.tsx
@@ -10,47 +10,76 @@ import { ArrowLeft } from "lucide-react"
 import type { Student } from "@/services/students"
 import type { Course } from "@/services/courses"
 import {
-  fetchEnrolledStudents,
+  fetchEnrolledStudentsWithCourses,
   assignCourses,
   unassignCourses,
 } from "@/services/students"
-import { fetchCourses } from "@/services/courses"
+import { fetchProgramCourses } from "@/services/courses"
 
 export default function CourseAssignmentDashboard() {
   const [students, setStudents] = useState<Student[]>([])
   const [courses, setCourses] = useState<Course[]>([])
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
   const [currentView, setCurrentView] = useState<"main" | "assignment">("main")
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     ;(async () => {
       try {
-        const [st, cr] = await Promise.all([fetchEnrolledStudents(), fetchCourses()])
+        const st = await fetchEnrolledStudentsWithCourses()
+        const programIds = Array.from(
+          new Set(st.map((s) => s.programId).filter((id) => id > 0)),
+        )
+        const coursesLists = await Promise.all(
+          programIds.map((id) => fetchProgramCourses(id)),
+        )
+        const cr = Array.from(
+          new Map(coursesLists.flat().map((c) => [c.id, c])).values(),
+        )
         setStudents(st)
         setCourses(cr)
       } catch (err) {
         console.error(err)
+      } finally {
+        setIsLoading(false)
       }
     })()
   }, [])
 
 
-  const handleBulkAssignment = async (studentIds: string[], courseIds: string[], isAssigned: boolean) => {
+  const handleBulkAssignment = async (
+    studentIds: string[],
+    courseIds: string[],
+    isAssigned: boolean,
+  ) => {
     setStudents((prev) =>
       prev.map((student) => {
         if (studentIds.includes(student.id)) {
           let updated = [...student.assignedCourses]
+          let updatedNames = [...student.assignedCourseNames]
           courseIds.forEach((courseId) => {
+            const course = courses.find((c) => c.id === Number(courseId))
+            const courseName = course?.name ?? ''
             if (isAssigned) {
-              if (!updated.includes(courseId)) updated.push(courseId)
+              if (!updated.includes(courseId)) {
+                updated.push(courseId)
+                if (courseName && !updatedNames.includes(courseName)) {
+                  updatedNames.push(courseName)
+                }
+              }
             } else {
               updated = updated.filter((id) => id !== courseId)
+              updatedNames = updatedNames.filter((n) => n !== courseName)
             }
           })
-          return { ...student, assignedCourses: updated }
+          return {
+            ...student,
+            assignedCourses: updated,
+            assignedCourseNames: updatedNames,
+          }
         }
         return student
-      })
+      }),
     )
 
     try {
@@ -93,6 +122,14 @@ export default function CourseAssignmentDashboard() {
   }
 
   const selectedStudent = selectedStudentId ? students.find((s) => s.id === selectedStudentId) : null
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-96">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    )
+  }
 
   if (currentView === "assignment" && selectedStudent) {
     return (

--- a/components/cards/student-card.tsx
+++ b/components/cards/student-card.tsx
@@ -52,7 +52,7 @@ export function StudentCard({ student, isSelected, onSelect, onViewAssignment }:
           </div>
         </div>
         
-        {student.assignedCourseNames.length > 0 && (
+        {student.assignedCourseNames.length > 0 ? (
           <div className="mt-2 text-xs text-gray-700 space-y-1">
             {student.assignedCourseNames.map((name) => (
               <div key={name} className="truncate">
@@ -60,6 +60,8 @@ export function StudentCard({ student, isSelected, onSelect, onViewAssignment }:
               </div>
             ))}
           </div>
+        ) : (
+          <p className="mt-2 text-xs text-gray-500 italic">Sin cursos asignados</p>
         )}
 
         <Button onClick={() => onViewAssignment(student.id)} className="w-full mt-4">
@@ -68,5 +70,4 @@ export function StudentCard({ student, isSelected, onSelect, onViewAssignment }:
         </Button>
       </CardContent>
     </Card>
-  )
-}
+  )}

--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -155,6 +155,7 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
   const [pendingAssign, setPendingAssign] = useState<string[]>([]);
   const [pendingUnassign, setPendingUnassign] = useState<string[]>([]);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     (async () => {
@@ -168,6 +169,8 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
         setAllCourses(courses);
       } catch (err) {
         console.error(err);
+      } finally {
+        setIsLoading(false);
       }
     })();
   }, [student.id, student.programId]);
@@ -247,6 +250,14 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
     },
     [searchTerm],
   );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">

--- a/services/students.ts
+++ b/services/students.ts
@@ -75,6 +75,34 @@ export const fetchEnrolledStudents = async (): Promise<Student[]> => {
   return students
 }
 
+export const fetchEnrolledStudentsWithCourses = async (): Promise<Student[]> => {
+  const res = await api.get('/prospectos/inscritos-with-courses', {
+    params: { per_page: 9999 },
+  })
+  const data = Array.isArray(res.data.data) ? res.data.data : res.data
+
+  return data.map((p: any) => {
+    const prog =
+      Array.isArray(p.programas) && p.programas.length > 0 ? p.programas[0] : null
+
+    return {
+      id: String(p.id),
+      name: p.nombre_completo ?? '',
+      carnet: String(p.id),
+      programId: prog?.id ?? 0,
+      program: prog?.nombre_del_programa ?? '',
+      specialty: prog?.abreviatura ?? '',
+      assignedCourses: Array.isArray(p.courses)
+        ? p.courses.map((c: any) => String(c.id))
+        : [],
+      assignedCourseNames: Array.isArray(p.courses)
+        ? p.courses.map((c: any) => c.name)
+        : [],
+      completedCourses: [],
+    }
+  })
+}
+
 export const fetchStudentCourseLists = async (
   studentId: string,
 ): Promise<{ assigned: Course[]; completed: Course[] }> => {


### PR DESCRIPTION
## Summary
- show a message when a student has no assigned courses
- update the bulk course assignment handler to keep course names in sync
- load only program courses in the assignment dashboard and add a spinner
- show loader in student assignment view
- add loading spinner for the asignacion route
- load assigned courses from the new `inscritos-with-courses` endpoint

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9ee4b99c8328b8dc45daa2e2164e