### PR TITLE
Fix ranking search filter

### DIFF
--- a/app/academico/ranking/page.tsx
+++ b/app/academico/ranking/page.tsx
@@ -82,9 +82,14 @@ export default function RankingAcademico() {
 
   // Filtrar estudiantes
   const filteredStudents = students.filter(student => {
-    const matchesSearch = 
-      student.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      student.program.toLowerCase().includes(searchTerm.toLowerCase())
+    const search = searchTerm.toLowerCase()
+    const nameMatch = student.name
+      ? student.name.toLowerCase().includes(search)
+      : false
+    const programMatch = student.program
+      ? student.program.toLowerCase().includes(search)
+      : false
+    const matchesSearch = nameMatch || programMatch
     
     const matchesProgram = programFilter === "all" || student.program === programFilter
     const matchesSemester = semesterFilter === "all" || student.semester.toString() === semesterFilter


### PR DESCRIPTION
## Summary
- handle undefined student names and programs when filtering rankings

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb9e90f30832895a4c00af0b51d3a