### PR TITLE
Fix ranking filter crash

### DIFF
--- a/app/academico/ranking/page.tsx
+++ b/app/academico/ranking/page.tsx
@@ -83,14 +83,19 @@ export default function RankingAcademico() {
   const uniqueSemesters = Array.from(new Set(students.map((s) => s.semester))).sort((a, b) => a - b)
 
   // Filtrar estudiantes
-  const filteredStudents = students.filter(student => {
-    const matchesSearch = 
-      student.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      student.program.toLowerCase().includes(searchTerm.toLowerCase())
-    
-    const matchesProgram = programFilter === "all" || student.program === programFilter
-    const matchesSemester = semesterFilter === "all" || student.semester.toString() === semesterFilter
-    
+  const filteredStudents = students.filter((student) => {
+    const name = student.name ?? ""
+    const program = student.program ?? ""
+
+    const matchesSearch =
+      name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      program.toLowerCase().includes(searchTerm.toLowerCase())
+
+    const matchesProgram =
+      programFilter === "all" || program === programFilter
+    const matchesSemester =
+      semesterFilter === "all" || String(student.semester ?? "") === semesterFilter
+
     return matchesSearch && matchesProgram && matchesSemester
   })
 


### PR DESCRIPTION
## Summary
- avoid calling `toLowerCase` on undefined fields in ranking page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebbd1d8988328b8bccae23fb609cb