### PR TITLE
Fix ranking filters when data fields are missing

### DIFF
--- a/app/academico/ranking/page.tsx
+++ b/app/academico/ranking/page.tsx
@@ -77,10 +77,22 @@ export default function RankingAcademico() {
   }, [])
 
   // Obtener programas únicos para el filtro
-  const uniquePrograms = Array.from(new Set(students.map((s) => s.program)))
+  const uniquePrograms = Array.from(
+    new Set(
+      students
+        .map((s) => s.program)
+        .filter((program) => program !== undefined && program !== null && program !== "")
+    )
+  )
 
   // Obtener semestres únicos para el filtro
-  const uniqueSemesters = Array.from(new Set(students.map((s) => s.semester))).sort((a, b) => a - b)
+  const uniqueSemesters = Array.from(
+    new Set(
+      students
+        .map((s) => s.semester)
+        .filter((semester) => semester !== undefined && semester !== null)
+    )
+  ).sort((a, b) => Number(a) - Number(b))
 
   // Filtrar estudiantes
   const filteredStudents = students.filter((student) => {


### PR DESCRIPTION
## Summary
- avoid undefined values when extracting unique program and semester filters

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec87d580483289cd9052ffb6649b4