### PR TITLE
Fix bulk assignment courses for students with no program

### DIFF
--- a/components/bulk-assignment-panel.tsx
+++ b/components/bulk-assignment-panel.tsx
@@ -102,6 +102,8 @@ export function BulkAssignmentPanel({
             {selectedStudents.map((student) => (
               <Badge key={student.id} variant="secondary">
                 {student.name}
+                {" "}
+                {student.program ? `(${student.program})` : ""}
               </Badge>
             ))}
           </div>

--- a/components/views/students-view.tsx
+++ b/components/views/students-view.tsx
@@ -63,12 +63,15 @@ export function StudentsView({ students, courses, onViewAssignment, onBulkAssign
     new Set(
       selectedStudents
         .map((id) => students.find((s) => s.id === id)?.programId)
-        .filter((id): id is number => id !== undefined)
+        .filter((id): id is number => id !== undefined && id > 0)
     )
   )
-  const bulkCourses = courses.filter((c) =>
-    c.programIds.some((pid) => selectedProgramIds.includes(pid))
-  )
+  const bulkCourses =
+    selectedProgramIds.length === 0
+      ? courses
+      : courses.filter((c) =>
+          selectedProgramIds.every((pid) => c.programIds.includes(pid))
+        )
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- handle students with missing program in bulk assignment view
- show program name for each selected student in bulk panel
- filter bulk assignment courses by intersection of selected programs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687035664a848328831abbf56ad2a938