### PR TITLE
Enable bulk course loading from backend

### DIFF
--- a/components/bulk-assignment-panel.tsx
+++ b/components/bulk-assignment-panel.tsx
@@ -9,11 +9,13 @@ import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { X, Users, BookOpen, Plus, Minus, Search, Filter } from "lucide-react"
+import { X, Users, BookOpen, Plus, Minus, Search, Filter, Loader2 } from "lucide-react"
 
 interface BulkAssignmentPanelProps {
   selectedStudents: Student[]
   courses: Course[]
+  isLoading: boolean
+  error: string | null
   onBulkAssignment: (studentIds: string[], courseIds: string[], isAssigned: boolean) => void
   onClose: () => void
 }
@@ -21,6 +23,8 @@ interface BulkAssignmentPanelProps {
 export function BulkAssignmentPanel({
   selectedStudents,
   courses,
+  isLoading,
+  error,
   onBulkAssignment,
   onClose,
 }: BulkAssignmentPanelProps) {
@@ -162,33 +166,42 @@ export function BulkAssignmentPanel({
             Cursos Disponibles ({selectedCourses.length} seleccionados de {filteredCourses.length})
           </h4>
           
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 max-h-60 overflow-y-auto">
-            {filteredCourses.length > 0 ? (
-              filteredCourses.map((course) => (
-                <div key={course.id} className="flex items-center space-x-2 p-2 border rounded">
-                  <Checkbox
-                    checked={selectedCourses.includes(course.id)}
-                    onCheckedChange={(checked) =>
-                      handleCourseSelect(course.id, checked as boolean)
-                    }
-                  />
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm">{course.name}</span>
-                      <Badge className={`${getTypeColor(course.area)} text-white text-xs`}>
-                        {getTypeLabel(course.area)}
-                      </Badge>
+          {isLoading ? (
+            <div className="flex justify-center py-6">
+              <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+            </div>
+          ) : (
+            <>
+              {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 max-h-60 overflow-y-auto">
+                {filteredCourses.length > 0 ? (
+                  filteredCourses.map((course) => (
+                    <div key={course.id} className="flex items-center space-x-2 p-2 border rounded">
+                      <Checkbox
+                        checked={selectedCourses.includes(course.id)}
+                        onCheckedChange={(checked) =>
+                          handleCourseSelect(course.id, checked as boolean)
+                        }
+                      />
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium text-sm">{course.name}</span>
+                          <Badge className={`${getTypeColor(course.area)} text-white text-xs`}>
+                            {getTypeLabel(course.area)}
+                          </Badge>
+                        </div>
+                        <p className="text-xs text-gray-500">{course.code}</p>
+                      </div>
                     </div>
-                    <p className="text-xs text-gray-500">{course.code}</p>
+                  ))
+                ) : (
+                  <div className="col-span-2 text-center py-4 text-sm text-gray-500">
+                    No se encontraron cursos con los filtros actuales
                   </div>
-                </div>
-              ))
-            ) : (
-              <div className="col-span-2 text-center py-4 text-sm text-gray-500">
-                No se encontraron cursos con los filtros actuales
+                )}
               </div>
-            )}
-          </div>
+            </>
+          )}
         </div>
 
         <div className="flex space-x-2 pt-4">

--- a/components/views/students-view.tsx
+++ b/components/views/students-view.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import type { Student } from "@/services/students"
 import type { Course } from "@/services/courses"
+import { getAvailableCoursesForStudents } from "@/services/courses"
 import { StudentCard } from "@/components/cards/student-card"
 import { BulkAssignmentPanel } from "@/components/bulk-assignment-panel"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -25,6 +26,9 @@ export function StudentsView({ students, courses, onViewAssignment, onBulkAssign
   const [filterSpecialty, setFilterSpecialty] = useState<string>("all")
   const [selectedStudents, setSelectedStudents] = useState<string[]>([])
   const [showBulkPanel, setShowBulkPanel] = useState(false)
+  const [bulkCourses, setBulkCourses] = useState<Course[]>([])
+  const [isLoadingBulk, setIsLoadingBulk] = useState(false)
+  const [bulkError, setBulkError] = useState<string | null>(null)
 
   const programs = Array.from(new Set(students.map((s) => s.program).filter(Boolean)))
   const specialties = Array.from(new Set(students.map((s) => s.specialty).filter(Boolean)))
@@ -59,21 +63,15 @@ export function StudentsView({ students, courses, onViewAssignment, onBulkAssign
     setSelectedStudents([])
   }
 
-  const selectedProgramIds = Array.from(
-    new Set(
-      selectedStudents
-        .map((id) => students.find((s) => s.id === id)?.programId)
-        .filter((id): id is number => id !== undefined && id > 0)
-    )
-  )
-  const bulkCourses =
-    selectedProgramIds.length === 0
-      ? courses
-      : courses.filter((c) =>
-
-          selectedProgramIds.every((pid) => c.programIds.includes(pid))
-
-        )
+  useEffect(() => {
+    if (!showBulkPanel) return
+    setIsLoadingBulk(true)
+    setBulkError(null)
+    getAvailableCoursesForStudents(selectedStudents)
+      .then((cursos) => setBulkCourses(cursos))
+      .catch(() => setBulkError('Error cargando cursos'))
+      .finally(() => setIsLoadingBulk(false))
+  }, [showBulkPanel, selectedStudents])
 
   return (
     <div className="space-y-6">
@@ -83,12 +81,14 @@ export function StudentsView({ students, courses, onViewAssignment, onBulkAssign
           <h2 className="text-2xl font-bold">Estudiantes ({filteredStudents.length})</h2>
           {selectedStudents.length > 0 && <Badge variant="secondary">{selectedStudents.length} seleccionados</Badge>}
         </div>
-        {selectedStudents.length > 0 && (
-          <Button onClick={() => setShowBulkPanel(true)} variant="outline">
-            <Settings className="h-4 w-4 mr-2" />
-            Asignación Masiva
-          </Button>
-        )}
+        <Button
+          onClick={() => setShowBulkPanel(true)}
+          variant="outline"
+          disabled={selectedStudents.length === 0}
+        >
+          <Settings className="h-4 w-4 mr-2" />
+          Asignación Masiva
+        </Button>
       </div>
 
       <Card>
@@ -154,6 +154,8 @@ export function StudentsView({ students, courses, onViewAssignment, onBulkAssign
         <BulkAssignmentPanel
           selectedStudents={selectedStudents.map((id) => students.find((s) => s.id === id)!)}
           courses={bulkCourses}
+          isLoading={isLoadingBulk}
+          error={bulkError}
           onBulkAssignment={onBulkAssignment}
           onClose={() => setShowBulkPanel(false)}
         />

--- a/services/courses.ts
+++ b/services/courses.ts
@@ -127,11 +127,12 @@ export const fetchFacilitators = async () => {
 
 
 /** Llama a GET /available-for-students?prospecto_ids[]=1&prospecto_ids[]=2 */
-export const fetchAvailableForStudents = async (
-  studentIds: string[]
+export const getAvailableCoursesForStudents = async (
+  prospectoIds: string[]
 ): Promise<Course[]> => {
   const res = await api.get('/available-for-students', {
-    params: { prospecto_ids: studentIds.map(Number) }
-  });
-  return Array.isArray(res.data) ? res.data : res.data.data;
-};
+    params: { prospecto_ids: prospectoIds.map(Number) },
+  })
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return data.map(mapCourseFromApi)
+}


### PR DESCRIPTION
## Summary
- add `getAvailableCoursesForStudents` service
- load available courses for selected students in `StudentsView`
- pass loading and error flags to `BulkAssignmentPanel`
- show spinner or error when loading courses in `BulkAssignmentPanel`

## Testing
- `npm run lint` *(fails: interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_687149fd464c8328ab5aaa7333dede9e