### PR TITLE
Add prospect program fetching in StudentCard

### DIFF
--- a/components/ProspectoDetail.tsx
+++ b/components/ProspectoDetail.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { fetchProspectoWithPrograms } from '@/services/prospectoService'
+import type { ProspectoConProgramas } from '@/types/prospecto'
+
+export function ProspectoDetail({ id }: { id: number }) {
+  const [prospecto, setProspecto] = useState<ProspectoConProgramas | null>(null)
+
+  useEffect(() => {
+    fetchProspectoWithPrograms(id).then(setProspecto).catch(console.error)
+  }, [id])
+
+  if (!prospecto) return <div>…Cargando prospecto…</div>
+
+  return (
+    <div>
+      <h1>{prospecto.nombre_completo}</h1>
+      <h2>Programas inscritos</h2>
+      <ul>
+        {prospecto.programas.map(ep => (
+          <li key={ep.id}>
+            {ep.programa.nombre_del_programa} ({ep.programa.abreviatura})
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/components/cards/student-card.tsx
+++ b/components/cards/student-card.tsx
@@ -1,6 +1,9 @@
 "use client"
 
 import type { Student } from "@/services/students"
+import { useEffect, useState } from "react"
+import { fetchProspectoWithPrograms } from "@/services/prospectoService"
+import type { Program } from "@/services/programs"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -15,6 +18,16 @@ interface StudentCardProps {
 }
 
 export function StudentCard({ student, isSelected, onSelect, onViewAssignment }: StudentCardProps) {
+  const [programs, setPrograms] = useState<Program[]>(student.programs)
+
+  useEffect(() => {
+    if (programs.length === 0) {
+      fetchProspectoWithPrograms(Number(student.id))
+        .then(res => setPrograms(res.programas.map(ep => ep.programa)))
+        .catch(console.error)
+    }
+  }, [student.id, programs.length])
+
   return (
     <Card className={`hover:shadow-md transition-shadow ${isSelected ? "ring-2 ring-blue-500" : ""}`}>
       <CardContent className="p-4">
@@ -30,11 +43,11 @@ export function StudentCard({ student, isSelected, onSelect, onViewAssignment }:
         <div className="space-y-2 text-sm text-gray-600 mb-4">
           <div>
             <span className="font-medium">Programa:</span>{" "}
-            {student.programs.map(p => p.nombre_del_programa).join(', ')}
+            {programs.map(p => p.nombre_del_programa).join(', ')}
           </div>
           <div>
             <span className="font-medium">Especialidad:</span>{" "}
-            {student.programs.map(p => p.abreviatura).join(', ')}
+            {programs.map(p => p.abreviatura).join(', ')}
           </div>
           <div className="flex justify-between">
             <div className="flex items-center space-x-1">

--- a/services/prospectoService.ts
+++ b/services/prospectoService.ts
@@ -1,0 +1,17 @@
+import api from './api'
+import type { ProspectoConProgramas, Prospecto } from '@/types/prospecto'
+
+/** Lista todos los prospectos (sin programas) */
+export async function fetchProspectos(): Promise<Prospecto[]> {
+  const res = await api.get('/prospectos')
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return data as Prospecto[]
+}
+
+/** Trae un prospecto junto con sus programas (programas.programa) */
+export async function fetchProspectoWithPrograms(
+  id: number
+): Promise<ProspectoConProgramas> {
+  const res = await api.get<{ data: ProspectoConProgramas }>(`/prospectos/${id}`)
+  return res.data.data
+}

--- a/types/prospecto.ts
+++ b/types/prospecto.ts
@@ -1,0 +1,22 @@
+import type { Program as Programa } from '@/services/programs'
+
+export interface EstudiantePrograma {
+  id: number
+  prospecto_id: number
+  programa_id: number
+  programa: Programa
+}
+
+/** Prospecto básico */
+export interface Prospecto {
+  id: number
+  nombre_completo: string
+  status: string
+  // …otros campos básicos
+}
+
+/** Prospecto con programas cargados */
+export interface ProspectoConProgramas extends Prospecto {
+  programas: EstudiantePrograma[]
+  courses: any[] // deja courses si ya lo manejas
+}


### PR DESCRIPTION
## Summary
- fetch programs when rendering each StudentCard if missing
- reference Program type in prospecto interfaces

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717fe630008328b1c58ac2b04e52d8