### PR TITLE
Add Moodle course fetching module

### DIFF
--- a/app/moodle/loading.tsx
+++ b/app/moodle/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null
+}

--- a/app/moodle/moodle-courses-client.tsx
+++ b/app/moodle/moodle-courses-client.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { fetchMoodleCourses, MoodleCourse } from "@/services/moodle"
+import MoodleCourseCard from "@/components/moodle/moodle-course-card"
+
+export default function MoodleCoursesClient() {
+  const [courses, setCourses] = useState<MoodleCourse[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchMoodleCourses()
+        setCourses(data)
+      } catch (err) {
+        console.error("Error fetching Moodle courses", err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  if (loading) {
+    return <div>Cargando cursos...</div>
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {courses.map(course => (
+        <MoodleCourseCard key={course.id} course={course} />
+      ))}
+    </div>
+  )
+}

--- a/app/moodle/page.tsx
+++ b/app/moodle/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next"
+import MoodleCoursesClient from "./moodle-courses-client"
+
+export const metadata: Metadata = {
+  title: "Cursos Moodle",
+  description: "Listado de cursos obtenidos de Moodle",
+}
+
+export default function MoodleCoursesPage() {
+  return (
+    <div className="container py-6">
+      <h1 className="text-2xl font-bold mb-4">Cursos en Moodle</h1>
+      <MoodleCoursesClient />
+    </div>
+  )
+}

--- a/components/moodle/moodle-course-card.tsx
+++ b/components/moodle/moodle-course-card.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { BookOpen } from "lucide-react"
+import type { MoodleCourse } from "@/services/moodle"
+
+interface Props {
+  course: MoodleCourse
+}
+
+export default function MoodleCourseCard({ course }: Props) {
+  return (
+    <Card className="hover:shadow-md transition-shadow">
+      <CardContent className="p-4">
+        <div className="flex items-center space-x-2">
+          <BookOpen className="h-5 w-5 text-blue-600" />
+          <h3 className="font-semibold text-lg">{course.fullname}</h3>
+        </div>
+        <div className="text-sm text-gray-600">{course.shortname}</div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/services/moodle.ts
+++ b/services/moodle.ts
@@ -1,0 +1,32 @@
+import axios from 'axios'
+
+const MOODLE_BASE_URL = process.env.NEXT_PUBLIC_MOODLE_URL || 'https://campusamerican.com'
+const MOODLE_TOKEN = process.env.NEXT_PUBLIC_MOODLE_TOKEN || ''
+const MOODLE_FORMAT = process.env.NEXT_PUBLIC_MOODLE_FORMAT || 'json'
+
+const moodleApi = axios.create({
+  baseURL: MOODLE_BASE_URL,
+})
+
+export interface MoodleCourse {
+  id: number
+  fullname: string
+  shortname: string
+  idnumber?: string
+  summary?: string
+}
+
+export const fetchMoodleCourses = async (): Promise<MoodleCourse[]> => {
+  const params = new URLSearchParams({
+    wstoken: MOODLE_TOKEN,
+    wsfunction: 'core_course_get_courses',
+    moodlewsrestformat: MOODLE_FORMAT,
+  })
+
+  const res = await moodleApi.get(`/webservice/rest/server.php?${params.toString()}`)
+  const data = res.data
+
+  if (Array.isArray(data)) return data as MoodleCourse[]
+  if (Array.isArray(data.courses)) return data.courses as MoodleCourse[]
+  return []
+}


### PR DESCRIPTION
## Summary
- create Moodle service to fetch courses via REST API
- add reusable course card component
- expose new `/moodle` page using the service and component

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch Google Fonts; missing packages 'react-dnd')*


------
https://chatgpt.com/codex/tasks/task_e_687a80e732148328bfc2092be32cc65a