### PR TITLE
Add Moodle integration submodule

### DIFF
--- a/app/academico/moodle/page.tsx
+++ b/app/academico/moodle/page.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { BookOpen } from "lucide-react"
+import { fetchMoodleCourses } from "@/services/moodle"
+
+interface MoodleCourse {
+  id: number
+  fullname: string
+}
+
+export default function MoodleCoursesPage() {
+  const [courses, setCourses] = useState<MoodleCourse[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchMoodleCourses()
+        const mapped = Array.isArray(data)
+          ? data.map((c: any) => ({ id: c.id, fullname: c.fullname }))
+          : []
+        setCourses(mapped)
+      } catch (err) {
+        console.error('Error fetching Moodle courses', err)
+      }
+    }
+    load()
+  }, [])
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/academico">Académico</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Cursos Moodle</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2">
+          <BookOpen className="h-6 w-6" />
+          <div>
+            <CardTitle>Cursos desde Moodle</CardTitle>
+            <CardDescription>Información obtenida vía API</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc pl-5 space-y-1">
+            {courses.map(course => (
+              <li key={course.id}>{course.fullname}</li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -44,6 +44,13 @@ export default function DashboardPage() {
       color: "bg-green-500",
     },
     {
+      title: "Cursos Moodle",
+      description: "Consulta de cursos desde Moodle",
+      icon: <BookOpen className="h-6 w-6" />,
+      href: "/academico/moodle",
+      color: "bg-yellow-500",
+    },
+    {
       title: "Docentes",
       description: "Gestión de cursos, material didáctico y comunicación con alumnos",
       icon: <GraduationCap className="h-6 w-6" />,

--- a/services/moodle.ts
+++ b/services/moodle.ts
@@ -1,0 +1,22 @@
+import axios from 'axios'
+
+const MOODLE_BASE_URL = process.env.NEXT_PUBLIC_MOODLE_URL || 'https://campusamerican.com'
+const MOODLE_TOKEN = process.env.NEXT_PUBLIC_MOODLE_TOKEN || ''
+const MOODLE_FORMAT = process.env.NEXT_PUBLIC_MOODLE_FORMAT || 'json'
+
+const moodleApi = axios.create({
+  baseURL: `${MOODLE_BASE_URL}/webservice/rest/server.php`,
+})
+
+export const fetchMoodleCourses = async () => {
+  const res = await moodleApi.get('', {
+    params: {
+      wstoken: MOODLE_TOKEN,
+      wsfunction: 'core_course_get_courses',
+      moodlewsrestformat: MOODLE_FORMAT,
+    },
+  })
+  return Array.isArray(res.data) ? res.data : res.data.courses || []
+}
+
+export default moodleApi


### PR DESCRIPTION
## Summary
- integrate Moodle API service
- list Moodle courses under Academico
- add Moodle section link in the dashboard

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b1468588328b40cc9873c9d7b8a