### PR TITLE
Add Moodle course sync support

### DIFF
--- a/app/academico/moodle/page.tsx
+++ b/app/academico/moodle/page.tsx
@@ -32,7 +32,11 @@ import { BookOpen } from "lucide-react"
 import Link from "next/link"
 import { format, startOfMonth, addMonths, isSameMonth } from "date-fns"
 import { es } from "date-fns/locale"
-import { fetchMoodleCourses, MOODLE_BASE_URL } from "@/services/moodle"
+import {
+  fetchMoodleCourses,
+  pushMoodleCourses,
+  MOODLE_BASE_URL,
+} from "@/services/moodle"
 
 const MONTH_NAMES = [
   "Enero",
@@ -52,6 +56,10 @@ const MONTH_NAMES = [
 interface MoodleCourse {
   id: number
   fullname: string
+  shortname: string
+  summary?: string
+  categoryid?: number
+  numsections?: number
   timecreated: number
 }
 
@@ -74,10 +82,14 @@ export default function MoodleCoursesPage() {
         const data = await fetchMoodleCourses()
         const mapped = Array.isArray(data)
           ? data.map((c: any) => ({
-            id: c.id,
-            fullname: c.fullname,
-            timecreated: c.timecreated ?? 0,
-          }))
+              id: c.id,
+              fullname: c.fullname,
+              shortname: c.shortname,
+              summary: c.summary,
+              categoryid: c.categoryid,
+              numsections: c.numsections,
+              timecreated: c.timecreated ?? 0,
+            }))
           : []
         mapped.sort((a, b) => b.timecreated - a.timecreated)
         setCourses(mapped)
@@ -169,6 +181,41 @@ export default function MoodleCoursesPage() {
     return ordered.concat(arr)
   }, [courses, search, selectedYear, selectedMonth, showMode, selectedCourses])
 
+  const handleSync = async () => {
+    const ids = Array.from(selectedCourses)
+    try {
+      await pushMoodleCourses(courses.filter(c => ids.includes(c.id)) as any)
+      toast({
+        title: 'Sincronización enviada',
+        description: `Se enviaron ${ids.length} cursos al backend`,
+      })
+    } catch (err) {
+      console.error('Error syncing courses', err)
+      toast({
+        title: 'Error al sincronizar',
+        description: 'No se pudieron enviar los cursos',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const handleSyncSingle = async (course: MoodleCourse) => {
+    try {
+      await pushMoodleCourses([course] as any)
+      toast({
+        title: 'Sincronización enviada',
+        description: `Curso ${course.fullname} enviado al backend`,
+      })
+    } catch (err) {
+      console.error('Error syncing course', err)
+      toast({
+        title: 'Error al sincronizar',
+        description: 'No se pudo enviar el curso',
+        variant: 'destructive',
+      })
+    }
+  }
+
   const totalPages = Math.max(1, Math.ceil(groups.length / perPage))
   const pagedGroups = groups.slice((page - 1) * perPage, page * perPage)
 
@@ -248,7 +295,11 @@ export default function MoodleCoursesPage() {
                 <SelectItem value="selected">Seleccionados</SelectItem>
               </SelectContent>
             </Select>
-            <Button variant="outline" disabled>
+            <Button
+              variant="outline"
+              onClick={handleSync}
+              disabled={selectedCourses.size === 0}
+            >
               Sincronizar seleccionados
             </Button>
           </div>
@@ -289,7 +340,11 @@ export default function MoodleCoursesPage() {
                       />
                     </CardHeader>
                     <CardFooter>
-                      <Button variant="outline" size="sm" disabled>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleSyncSingle(course)}
+                      >
                         Sincronizar curso
                       </Button>
                     </CardFooter>

--- a/services/moodle.ts
+++ b/services/moodle.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError } from 'axios';
+import api from './api';
 
 export const MOODLE_BASE_URL =
   process.env.NEXT_PUBLIC_MOODLE_URL || 'https://campusamerican.com';
@@ -16,6 +17,24 @@ const moodleApi = axios.create({
 const moodleApiIp = MOODLE_IP_URL
   ? axios.create({ baseURL: `${MOODLE_IP_URL}/webservice/rest/server.php` })
   : null;
+
+export interface MoodleCourse {
+  id: number
+  fullname: string
+  shortname: string
+  summary?: string
+  categoryid?: number
+  numsections?: number
+}
+
+export const mapMoodleCourse = (course: any): MoodleCourse => ({
+  id: course.id,
+  fullname: course.fullname,
+  shortname: course.shortname,
+  summary: course.summary ?? '',
+  categoryid: course.categoryid,
+  numsections: course.numsections,
+})
 
 export const fetchMoodleCourses = async (): Promise<any[]> => {
   const params = {
@@ -39,6 +58,11 @@ export const fetchMoodleCourses = async (): Promise<any[]> => {
     }
     throw err;
   }
+};
+
+export const pushMoodleCourses = async (courses: any[]): Promise<void> => {
+  const payload = courses.map(mapMoodleCourse);
+  await api.post('/moodle/courses', payload);
 };
 
 export default moodleApi;


### PR DESCRIPTION
## Summary
- expose MoodleCourse type and mapping utilities
- provide function for posting Moodle courses to backend
- extend Moodle admin page to push course data to backend

## Testing
- `npm -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb37e2e4c83289cac6b0f89fa4269