### PR TITLE
Fix student import path and add loader

### DIFF
--- a/app/academico/migrar-estudiantes/loading.tsx
+++ b/app/academico/migrar-estudiantes/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center h-96">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+    </div>
+  )
+}

--- a/app/academico/migrar-estudiantes/page.tsx
+++ b/app/academico/migrar-estudiantes/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft, Loader2 } from "lucide-react"
 import { API_BASE_URL } from "@/utils/apiConfig"
 import { useToast } from "@/components/ui/use-toast"
 import { useRouter } from "next/navigation"
@@ -11,6 +11,7 @@ import Swal from "sweetalert2"
 
 export default function MigrarEstudiantes() {
   const [file, setFile] = useState<File | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
   const { toast } = useToast()
   const router = useRouter()
 
@@ -31,7 +32,8 @@ export default function MigrarEstudiantes() {
     const token = localStorage.getItem("token")
 
     try {
-      const res = await fetch(`${API_BASE_URL}/api/import`, {
+      setIsLoading(true)
+      const res = await fetch(`${API_BASE_URL}/api/estudiantes/import`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
         body: formData,
@@ -45,6 +47,8 @@ export default function MigrarEstudiantes() {
       console.error("Error en import:", error)
       Swal.fire({ icon: "error", title: "Error en la importación", text: error.message })
       toast({ title: "Error", description: "No se pudieron importar los datos", variant: "destructive" })
+    } finally {
+      setIsLoading(false)
     }
   }
 
@@ -61,7 +65,16 @@ export default function MigrarEstudiantes() {
       <div className="bg-white p-6 rounded-lg shadow-sm space-y-4">
         <label className="block text-sm font-medium">Archivo CSV o Excel</label>
         <Input type="file" accept=".csv,.xlsx,.xls" onChange={handleFileChange} />
-        <Button onClick={handleImport}>Importar Estudiantes</Button>
+        <Button onClick={handleImport} disabled={isLoading}>
+          {isLoading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Importando...
+            </>
+          ) : (
+            "Importar Estudiantes"
+          )}
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- use `/api/estudiantes/import` endpoint when migrating students
- show spinner on "Importar Estudiantes" button while uploading
- add page-level loading UI for migrar-estudiantes route

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68828f233a948328aff7bc13cef64962