### PR TITLE
Add progress bar to student import

### DIFF
--- a/app/academico/migrar-estudiantes/page.tsx
+++ b/app/academico/migrar-estudiantes/page.tsx
@@ -3,21 +3,37 @@
 import React, { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Progress } from "@/components/ui/progress"
 import { ArrowLeft, Loader2 } from "lucide-react"
 import { API_BASE_URL } from "@/utils/apiConfig"
 import { useToast } from "@/components/ui/use-toast"
 import { useRouter } from "next/navigation"
 import Swal from "sweetalert2"
+import api from "@/services/api"
+import * as XLSX from "xlsx"
 
 export default function MigrarEstudiantes() {
   const [file, setFile] = useState<File | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [progress, setProgress] = useState(0)
   const { toast } = useToast()
   const router = useRouter()
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0]
     if (selected) setFile(selected)
+  }
+
+  const logFileContent = async (file: File) => {
+    try {
+      const buffer = await file.arrayBuffer()
+      const workbook = XLSX.read(buffer, { type: "array" })
+      const sheet = workbook.Sheets[workbook.SheetNames[0]]
+      const rows: any[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 })
+      rows.forEach((row, idx) => console.log(`[Migrar] Fila ${idx + 1}:`, row))
+    } catch (err) {
+      console.error("[Migrar] Error al leer archivo", err)
+    }
   }
 
   const handleImport = async () => {
@@ -50,13 +66,17 @@ export default function MigrarEstudiantes() {
 
     try {
       setIsLoading(true)
+      setProgress(0)
+      await logFileContent(file)
 
-      const res = await fetch(`${API_BASE_URL}/api/estudiantes/import`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
+      const res = await api.post(`${API_BASE_URL}/api/estudiantes/import`, formData, {
+        headers: { Authorization: `Bearer ${token}` },
+        onUploadProgress: (e) => {
+          if (e.total) {
+            const pct = Math.round((e.loaded * 100) / e.total)
+            setProgress(pct)
+          }
         },
-        body: formData,
       })
 
       // Manejo específico de 404
@@ -67,19 +87,14 @@ export default function MigrarEstudiantes() {
       }
 
       // Cualquier otro error HTTP
-      if (!res.ok) {
+      if (res.status < 200 || res.status >= 300) {
         let msg = `HTTP error ${res.status}`
-        try {
-          const errJson = await res.json()
-          if (errJson.message) msg = errJson.message
-        } catch {
-          // Si la respuesta no es JSON, ignoramos
-        }
+        if (res.data?.message) msg = res.data.message
         throw new Error(msg)
       }
 
-      // Éxito: parseamos JSON seguro
-      const data = await res.json()
+      // Éxito
+      const data = res.data
       Swal.fire({
         icon: "success",
         title: "Importación completada",
@@ -131,6 +146,12 @@ export default function MigrarEstudiantes() {
             "Importar Estudiantes"
           )}
         </Button>
+        {isLoading && (
+          <div className="space-y-1">
+            <Progress value={progress} />
+            <div className="text-sm text-muted-foreground">{progress}%</div>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- show upload progress when importing students
- log processed rows to console

## Testing
- `npx tsc --noEmit` *(fails: Property errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882f114ea448328a2933b9da15b0d48