### PR TITLE
Improve data fetching with pagination

### DIFF
--- a/app/academico/inactivar-estudiantes/page.tsx
+++ b/app/academico/inactivar-estudiantes/page.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Search, Ban } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Checkbox } from "@/components/ui/checkbox"
+import { toast } from "@/hooks/use-toast"
+import { Student, fetchEnrolledStudents, inactivateStudents } from "@/services/students"
+
+export default function InactivarEstudiantes() {
+  const [students, setStudents] = useState<Student[]>([])
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [searchTerm, setSearchTerm] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    fetchEnrolledStudents()
+      .then(setStudents)
+      .catch((err) => console.error(err))
+  }, [])
+
+  const filtered = students.filter(
+    (s) =>
+      s.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      s.carnet.toLowerCase().includes(searchTerm.toLowerCase())
+  )
+
+  const toggleSelectAll = (checked: boolean) => {
+    setSelectedIds(checked ? filtered.map((s) => s.id) : [])
+  }
+
+  const toggleSelectOne = (id: string, checked: boolean) => {
+    setSelectedIds((prev) =>
+      checked ? [...prev, id] : prev.filter((p) => p !== id)
+    )
+  }
+
+  const handleInactivate = async () => {
+    if (selectedIds.length === 0) return
+    setLoading(true)
+    try {
+      await inactivateStudents(selectedIds)
+      toast({ title: "Estudiantes inactivados" })
+      setSelectedIds([])
+      // Optionally reload students
+      const data = await fetchEnrolledStudents()
+      setStudents(data)
+    } catch (err) {
+      console.error(err)
+      toast({
+        title: "Error",
+        description: "No se pudo inactivar estudiantes",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <Card>
+        <CardHeader className="flex justify-between items-center">
+          <CardTitle>Inactivar Estudiantes</CardTitle>
+          <div className="relative w-64">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Buscar..."
+              className="pl-8"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-4">
+            <Button onClick={handleInactivate} disabled={loading || selectedIds.length === 0}>
+              <Ban className="mr-2 h-4 w-4" />
+              {loading ? "Procesando..." : "Inactivar Seleccionados"}
+            </Button>
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>
+                  <Checkbox
+                    checked={selectedIds.length === filtered.length && filtered.length > 0}
+                    onCheckedChange={(checked) => toggleSelectAll(!!checked)}
+                  />
+                </TableHead>
+                <TableHead>Nombre</TableHead>
+                <TableHead>Carnet</TableHead>
+                <TableHead>Programa</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell>
+                    <Checkbox
+                      checked={selectedIds.includes(s.id)}
+                      onCheckedChange={(checked) => toggleSelectOne(s.id, !!checked)}
+                    />
+                  </TableCell>
+                  <TableCell>{s.name}</TableCell>
+                  <TableCell>{s.carnet}</TableCell>
+                  <TableCell>{s.program}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, type ReactNode } from "react"
 import {
   BarChart2, Calendar, ChevronDown, ChevronRight, FileText, Home, Mail, Settings, Shield, Users, DollarSign,
   BookOpen, ClipboardList, Activity, Copy, UserCheck, Plus, FileSignature, BarChart, LayoutDashboard, GraduationCapIcon,
+  Ban,
   CreditCard, Bell, Award, Medal, PieChart, RefreshCw, Phone, FileCheck, Send, Key, LogIn, Database, Clock, LogOut
 } from "lucide-react"
 import Link from "next/link"
@@ -389,6 +390,10 @@ export default function Sidebar({ open, className }: SidebarProps) {
                 >
                   <UserCheck size={16} className="mr-2" />
                   <span>Estatus Académico</span>
+                </Link>
+                <Link href="/academico/inactivar-estudiantes" className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/inactivar-estudiantes" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"} transition-colors duration-200`}>
+                  <Ban size={16} className="mr-2" />
+                  <span>Inactivar Estudiantes</span>
                 </Link>
                 {/* <Link
                   href="/academico/estado-sistema"

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   ClipboardList,
   Activity,
   UserCheck,
+  Ban,
   Plus,
   FileSignature,
   BarChart,
@@ -206,9 +207,13 @@ export default function Sidebar({ open, className }: SidebarProps) {
               </button>
               {expandedSections.academico && (
                 <div className="pl-10 text-sm">
-                  <Link href="/academico/programas" className={linkClass("/academico/programas")}>
+                  <Link href="/academico/programas" className={linkClass("/academico/programas")}> 
                     <BookOpen size={16} className="mr-2" />
                     Programas Académicos
+                  </Link>
+                  <Link href="/academico/inactivar-estudiantes" className={linkClass("/academico/inactivar-estudiantes")}> 
+                    <Ban size={16} className="mr-2" />
+                    Inactivar Estudiantes
                   </Link>
                 </div>
               )}

--- a/services/courses.ts
+++ b/services/courses.ts
@@ -56,11 +56,23 @@ const mapCourseToApi = (data: Partial<CourseInput> & { status?: Course['status']
 }
 
 export const fetchCourses = async (programId?: number) => {
-  const res = await api.get('/courses', {
-    params: programId ? { program_id: programId } : undefined,
-  })
-  const data = Array.isArray(res.data) ? res.data : res.data.data
-  return data.map(mapCourseFromApi)
+  const perPage = 200
+  let page = 1
+  const courses: Course[] = []
+  const baseParams = programId ? { program_id: programId } : {}
+
+  while (true) {
+    const res = await api.get('/courses', {
+      params: { ...baseParams, per_page: perPage, page },
+    })
+    const data = Array.isArray(res.data) ? res.data : res.data.data
+    courses.push(...data.map(mapCourseFromApi))
+
+    if (data.length < perPage) break
+    page++
+  }
+
+  return courses
 }
 
 export const fetchProgramCourses = async (programId: number) => {

--- a/services/students.ts
+++ b/services/students.ts
@@ -32,45 +32,54 @@ export const fetchStudentProgram = async (
 }
 
 export const fetchEnrolledStudents = async (): Promise<Student[]> => {
-  const res = await api.get('/prospectos/status/Inscrito', {
-    params: { per_page: 9999 },
-  })
-  const data = Array.isArray(res.data.data) ? res.data.data : res.data
+  const perPage = 200
+  let page = 1
+  const students: Student[] = []
 
-  const students = await Promise.all(
-    data.map(async (p: any) => {
-      // Intentamos leer el programa desde p.programas
-      let prog =
-        Array.isArray(p.programas) && p.programas.length > 0
-          ? p.programas[0]
-          : null
+  while (true) {
+    const res = await api.get('/prospectos/status/Inscrito', {
+      params: { per_page: perPage, page },
+    })
+    const data = Array.isArray(res.data.data) ? res.data.data : res.data
 
-      // Si no hay, lo pedimos al endpoint
-      if (!prog) {
-        try {
-          prog = await fetchStudentProgram(String(p.id))
-        } catch (err) {
-          console.error('Error fetching student program', err)
+    const pageStudents = await Promise.all(
+      data.map(async (p: any) => {
+        let prog =
+          Array.isArray(p.programas) && p.programas.length > 0
+            ? p.programas[0]
+            : null
+
+        if (!prog) {
+          try {
+            prog = await fetchStudentProgram(String(p.id))
+          } catch (err) {
+            console.error('Error fetching student program', err)
+          }
         }
-      }
 
-      return {
-        id: String(p.id),
-        name: p.nombre_completo ?? '',
-        carnet: String(p.id),
-        programId: prog?.id ?? 0,
-        program: prog?.nombre_del_programa ?? '',
-        specialty: prog?.abreviatura ?? '',
-        assignedCourses: Array.isArray(p.courses)
-          ? p.courses.map((c: any) => String(c.id))
-          : [],
-        assignedCourseNames: Array.isArray(p.courses)
-          ? p.courses.map((c: any) => c.name)
-          : [],
-        completedCourses: [],
-      }
-    }),
-  )
+        return {
+          id: String(p.id),
+          name: p.nombre_completo ?? '',
+          carnet: String(p.id),
+          programId: prog?.id ?? 0,
+          program: prog?.nombre_del_programa ?? '',
+          specialty: prog?.abreviatura ?? '',
+          assignedCourses: Array.isArray(p.courses)
+            ? p.courses.map((c: any) => String(c.id))
+            : [],
+          assignedCourseNames: Array.isArray(p.courses)
+            ? p.courses.map((c: any) => c.name)
+            : [],
+          completedCourses: [],
+        }
+      }),
+    )
+
+    students.push(...pageStudents)
+
+    if (data.length < perPage) break
+    page++
+  }
 
   return students
 }
@@ -134,4 +143,25 @@ export const unassignCourses = async (
     prospecto_ids: studentIds.map(Number),
     course_ids: courseIds.map(Number),
   })
+}
+
+export const updateStudentStatus = async (
+  studentId: string,
+  status: string,
+) => {
+  await api.put(`/prospectos/${studentId}/status`, { status })
+}
+
+export const bulkUpdateStudentStatus = async (
+  studentIds: string[],
+  status: string,
+) => {
+  await api.put('/prospectos/bulk-update-status', {
+    prospecto_ids: studentIds.map(Number),
+    status,
+  })
+}
+
+export const inactivateStudents = async (studentIds: string[]) => {
+  await bulkUpdateStudentStatus(studentIds, 'Inactivo')
 }


### PR DESCRIPTION
## Summary
- fetch students and courses using paginated requests to avoid huge payloads
- allow bulk update of student status in services
- add new CRUD-style page to inactivate students in Academico module
- expose new page from the sidebar

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint config prompts interactively)*

------
https://chatgpt.com/codex/tasks/task_e_6883c58804788328b7d9be70b17f5585