### PR TITLE
Improve data fetching for large datasets

### DIFF
--- a/services/courses.ts
+++ b/services/courses.ts
@@ -1,4 +1,5 @@
 import api from './api'
+import { fetchAllPages } from './pagination'
 
 export interface CourseInput {
   name: string
@@ -56,10 +57,10 @@ const mapCourseToApi = (data: Partial<CourseInput> & { status?: Course['status']
 }
 
 export const fetchCourses = async (programId?: number) => {
-  const res = await api.get('/courses', {
-    params: programId ? { program_id: programId } : undefined,
-  })
-  const data = Array.isArray(res.data) ? res.data : res.data.data
+  const data = await fetchAllPages<any>(
+    '/courses',
+    programId ? { program_id: programId } : {},
+  )
   return data.map(mapCourseFromApi)
 }
 

--- a/services/pagination.ts
+++ b/services/pagination.ts
@@ -1,0 +1,32 @@
+import api from './api'
+
+/**
+ * Fetch all pages from a paginated endpoint.
+ * The backend must support `page` and `per_page` query parameters.
+ * Results from each page are concatenated and returned as a single array.
+ * @param endpoint API endpoint (e.g. '/courses')
+ * @param params Additional query params
+ * @param perPage Number of records per request
+ */
+export async function fetchAllPages<T>(
+  endpoint: string,
+  params: Record<string, any> = {},
+  perPage = 100,
+): Promise<T[]> {
+  let page = 1
+  const all: T[] = []
+  while (true) {
+    const res = await api.get(endpoint, {
+      params: { ...params, page, per_page: perPage },
+    })
+    const data = Array.isArray(res.data.data) ? res.data.data : res.data
+    if (Array.isArray(data)) {
+      all.push(...data)
+      if (data.length < perPage) break
+    } else {
+      break
+    }
+    page += 1
+  }
+  return all
+}

--- a/services/students.ts
+++ b/services/students.ts
@@ -1,4 +1,5 @@
 import api from './api'
+import { fetchAllPages } from './pagination'
 import type { Program } from './programs'
 import type { Course } from './courses'
 
@@ -47,10 +48,7 @@ export const fetchStudentProgram = async (
 }
 
 export const fetchEnrolledStudents = async (): Promise<Student[]> => {
-  const res = await api.get('/prospectos/status/Inscrito', {
-    params: { per_page: 9999 },
-  })
-  const data = Array.isArray(res.data.data) ? res.data.data : res.data
+  const data = await fetchAllPages<any>('/prospectos/status/Inscrito')
 
   const students = await Promise.all(
     data.map(async (p: any) => {


### PR DESCRIPTION
## Summary
- add a helper `fetchAllPages` to request paginated results
- use `fetchAllPages` in course and student services

## Testing
- `npm run lint` *(fails: configuration prompt)*
- `npm run build` *(fails: cannot fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6883ed40b9108328bcc1ee4975d5591f