### PR TITLE
Add startDate field to Student

### DIFF
--- a/components/cards/student-card.tsx
+++ b/components/cards/student-card.tsx
@@ -34,6 +34,11 @@ export function StudentCard({ student, isSelected, onSelect, onViewAssignment }:
           <div>
             <span className="font-medium">Especialidad:</span> {student.specialty}
           </div>
+          {student.startDate && (
+            <div>
+              <span className="font-medium">Inicio:</span> {student.startDate}
+            </div>
+          )}
           <div className="flex justify-between">
             <div className="flex items-center space-x-1">
               <BookOpen className="h-4 w-4" />

--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -272,6 +272,12 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
               <span className="font-medium text-gray-600">Especialidad:</span>
               <p className="text-gray-900">{student.specialty}</p>
             </div>
+            {student.startDate && (
+              <div>
+                <span className="font-medium text-gray-600">Inicio:</span>
+                <p className="text-gray-900">{student.startDate}</p>
+              </div>
+            )}
             <div>
               <span className="font-medium text-gray-600">Cursos Asignados:</span>
               <p className="text-gray-900">{assigned.length}</p>

--- a/services/students.ts
+++ b/services/students.ts
@@ -9,6 +9,7 @@ export interface Student {
   programId: number
   program: string
   specialty: string
+  startDate?: string | null
   assignedCourses: string[]
   assignedCourseNames: string[]
   completedCourses: string[]
@@ -64,6 +65,7 @@ export const fetchEnrolledStudents = async (): Promise<Student[]> => {
           programId: prog?.id ?? 0,
           program: prog?.nombre_del_programa ?? '',
           specialty: prog?.abreviatura ?? '',
+          startDate: p.fecha_inicio_especifica ?? null,
           assignedCourses: Array.isArray(p.courses)
             ? p.courses.map((c: any) => String(c.id))
             : [],


### PR DESCRIPTION
## Summary
- allow startDate on Student interface
- expose student startDate from the enrollment fetch
- show start date in StudentCard and StudentAssignmentView

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6887f57f5b3483288d201fe76bec6586