### PR TITLE
Add ESLint config for Next.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "eslint": "latest",
+    "eslint-config-next": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- add an `.eslintrc.json` extending Next.js defaults
- include ESLint packages as dev dependencies

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f5d2f17c8328ab3e4771971cd261