### PR TITLE
Improve inscription UX and list ordering

### DIFF
--- a/components/gestion/gestion-prospectos.tsx
+++ b/components/gestion/gestion-prospectos.tsx
@@ -110,6 +110,13 @@ export default function GestionProspectos() {
             ultimoCambio: item.updated_at ?? "N/A",
           }))
           .filter((p: any) => p.estado.toLowerCase() !== "preinscripción")
+          .sort((a: Prospecto, b: Prospecto) => {
+            const getTime = (d: string) => {
+              const t = new Date(d).getTime()
+              return isNaN(t) ? 0 : t
+            }
+            return getTime(b.ultimoCambio) - getTime(a.ultimoCambio)
+          })
         setProspectos(list)
       } catch (err: any) {
         setError(err.message || "Error inesperado")

--- a/components/inscripcion/registration-form.tsx
+++ b/components/inscripcion/registration-form.tsx
@@ -33,6 +33,7 @@ export default function RegistrationForm() {
   const [progress, setProgress] = useState(20)
   const [showModal, setShowModal] = useState(false)
   const [prospectoId, setProspectoId] = useState<number | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const [datosPersonales, setDatosPersonales] = useState<DatosPersonales>({
     nombre: "", paisOrigen: "", paisResidencia: "", telefono: "",
@@ -74,6 +75,8 @@ export default function RegistrationForm() {
   }
 
   const handleFinalizarInscripcion = async () => {
+    if (isSubmitting) return
+    setIsSubmitting(true)
     try {
       const response = await axios.post(
         `${API_BASE_URL}/api/inscripciones/finalizar`,
@@ -120,7 +123,7 @@ export default function RegistrationForm() {
           window.location.reload();
         }
       });
-  
+
     } catch (error: any) {
       console.error("Error al finalizar inscripción:", error.response?.data || error);
       Swal.fire({
@@ -128,6 +131,8 @@ export default function RegistrationForm() {
         text: error.response?.data?.message || "Ocurrió un error",
         icon: 'error',
       });
+    } finally {
+      setIsSubmitting(false)
     }
   };
   
@@ -195,6 +200,7 @@ export default function RegistrationForm() {
                 setDocumentos={setDocumentos}
                 goPrev={() => changeTab("financiero")}
                 onFinalizar={handleFinalizarInscripcion}
+                isFinalizing={isSubmitting}
                 prospectoId={prospectoId as number}
               />
             </TabsContent>

--- a/components/inscripcion/tabs/DocumentosTab.tsx
+++ b/components/inscripcion/tabs/DocumentosTab.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, useRef, useMemo, Dispatch, SetStateAction } from "react"
 import axios, { AxiosError } from "axios"
 import { API_BASE_URL } from "@/utils/apiConfig"
-import { ArrowLeft, ArrowRight, FileText, Info, Upload, X, CheckCircle } from "lucide-react"
+import { ArrowLeft, ArrowRight, FileText, Info, Upload, X, CheckCircle, Loader2 } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
@@ -35,6 +35,7 @@ type Props = {
   goPrev: () => void
   prospectoId: number
   onFinalizar?: () => Promise<void>
+  isFinalizing?: boolean
 }
 
 export default function DocumentosTab({
@@ -43,6 +44,7 @@ export default function DocumentosTab({
   goPrev,
   prospectoId,
   onFinalizar,
+  isFinalizing,
 }: Props) {
   const hiddenInput = useRef<HTMLInputElement>(null)
   const uploadTarget = useRef<string | null>(null)
@@ -207,11 +209,17 @@ export default function DocumentosTab({
 
         {onFinalizar ? (
           <Button
-            disabled={!isFormValid}
+            disabled={!isFormValid || isFinalizing}
             onClick={onFinalizar}
             className={isFormValid ? "bg-green-600 hover:bg-green-700 text-white w-full sm:w-auto" : "w-full sm:w-auto"}
           >
-            Finalizar inscripción <ArrowRight className="ml-2 h-4 w-4" />
+            {isFinalizing ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Finalizando...
+              </>
+            ) : (
+              <>Finalizar inscripción <ArrowRight className="ml-2 h-4 w-4" /></>
+            )}
           </Button>
         ) : (
           <Link href="/inscripcion/revision" className="w-full sm:w-auto">


### PR DESCRIPTION
## Summary
- disable multiple submissions when finalizing inscription
- show spinner while inscription submission completes
- sort gestion prospects by most recent update

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: failed to fetch Google Fonts and metadata export error)*
- `npx tsc -p tsconfig.json` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6888dd4c49a083289719afbeb41334d9