### PR TITLE
Improve loader and prospect ordering

### DIFF
--- a/app/correos/page.tsx
+++ b/app/correos/page.tsx
@@ -110,15 +110,23 @@ export default function GestionProspectosEmail() {
         }
         const json = await res.json()
         // Mapear los datos obtenidos al modelo de prospecto
-        const prospectosTransformados = json.data.map((item: any) => ({
-          id: String(item.id),
-          nombre: item.nombre_completo,
-          email: item.correo_electronico,
-          telefono: item.telefono,
-          departamento: item.empresa_donde_labora_actualmente ?? "Sin Departamento",
-          estado: item.status || "No contactado",
-          ultimoCambio: item.updated_at ?? "N/A",
-        }))
+        const prospectosTransformados = json.data
+          .map((item: any) => ({
+            id: String(item.id),
+            nombre: item.nombre_completo,
+            email: item.correo_electronico,
+            telefono: item.telefono,
+            departamento: item.empresa_donde_labora_actualmente ?? "Sin Departamento",
+            estado: item.status || "No contactado",
+            ultimoCambio: item.updated_at ?? "N/A",
+          }))
+          .sort((a: Prospecto, b: Prospecto) => {
+            const getTime = (d: string) => {
+              const t = new Date(d).getTime()
+              return isNaN(t) ? 0 : t
+            }
+            return getTime(b.ultimoCambio) - getTime(a.ultimoCambio)
+          })
         setProspectos(prospectosTransformados)
       } catch (err: any) {
         console.error("Error al obtener prospectos:", err)

--- a/app/leads-asignados/page.tsx
+++ b/app/leads-asignados/page.tsx
@@ -70,15 +70,23 @@ export default function GestionProspectos() {
         }
         const json = await res.json()
         // Mapeamos los datos del backend a nuestro modelo de prospecto
-        const prospectosTransformados = json.data.map((item: any) => ({
-          id: String(item.id),
-          nombre: item.nombre_completo,
-          email: item.correo_electronico,
-          telefono: item.telefono,
-          departamento: item.empresa_donde_labora_actualmente ?? "Sin Departamento",
-          estado: item.status || "No contactado",
-          ultimoCambio: item.updated_at ?? "N/A",
-        }))
+        const prospectosTransformados = json.data
+          .map((item: any) => ({
+            id: String(item.id),
+            nombre: item.nombre_completo,
+            email: item.correo_electronico,
+            telefono: item.telefono,
+            departamento: item.empresa_donde_labora_actualmente ?? "Sin Departamento",
+            estado: item.status || "No contactado",
+            ultimoCambio: item.updated_at ?? "N/A",
+          }))
+          .sort((a: Prospecto, b: Prospecto) => {
+            const getTime = (d: string) => {
+              const t = new Date(d).getTime()
+              return isNaN(t) ? 0 : t
+            }
+            return getTime(b.ultimoCambio) - getTime(a.ultimoCambio)
+          })
         setProspectos(prospectosTransformados)
       } catch (err: any) {
         setError(err.message || "Error inesperado")

--- a/app/seguimiento/page.tsx
+++ b/app/seguimiento/page.tsx
@@ -30,6 +30,7 @@ interface Prospecto {
   nombre: string;
   email: string;
   telefono: string;
+  ultimoCambio: string;
   estado: "Contactado" | "Interesado" | "En proceso";
   asesor: string;
 }
@@ -135,14 +136,23 @@ export default function SeguimientoPage() {
         const res = await api.get("/prospectos");
         const json = res.data;
         console.log("Respuesta completa de prospectos:", json);
-        const prospectosTransformados: Prospecto[] = json.data.map((item: any) => ({
-          id: String(item.id),
-          nombre: item.nombre_completo,
-          email: item.correo_electronico,
-          telefono: item.telefono,
-          estado: item.status,
-          asesor: item.asesor || "Sin asignar",
-        }));
+        const prospectosTransformados: Prospecto[] = json.data
+          .map((item: any) => ({
+            id: String(item.id),
+            nombre: item.nombre_completo,
+            email: item.correo_electronico,
+            telefono: item.telefono,
+            estado: item.status,
+            asesor: item.asesor || "Sin asignar",
+            ultimoCambio: item.updated_at ?? "N/A",
+          }))
+          .sort((a, b) => {
+            const getTime = (d: string) => {
+              const t = new Date(d).getTime();
+              return isNaN(t) ? 0 : t;
+            };
+            return getTime(b.ultimoCambio) - getTime(a.ultimoCambio);
+          });
         setProspectos(prospectosTransformados);
       } catch (err: any) {
         console.error("Error en fetchProspectos:", JSON.stringify(err, null, 2));

--- a/components/admin/lead-management.tsx
+++ b/components/admin/lead-management.tsx
@@ -68,27 +68,35 @@ export default function GestionProspectos() {
     })
       .then(r => r.json())
       .then(json => {
-        const arr: Prospecto[] = (json.data || []).map((item: any) => {
-          const c = item.creator
-          const nombreAsesor = c
-            ? c.full_name ??
-            (c.first_name && c.last_name
-              ? `${c.first_name} ${c.last_name}`
-              : c.username ?? "—")
-            : null
-          return {
-            id: String(item.id),
-            nombre: item.nombre_completo,
-            email: item.correo_electronico,
-            telefono: item.telefono,
-            departamento:
-              item.empresa_donde_labora_actualmente ?? "Sin Departamento",
-            estado: item.status || "No contactado",
-            ultimoCambio: item.updated_at ?? "N/A",
-            asesor_id: c?.id ?? null,
-            asesor: c ? { id: c.id, nombre: nombreAsesor } : null,
-          }
-        })
+        const arr: Prospecto[] = (json.data || [])
+          .map((item: any) => {
+            const c = item.creator
+            const nombreAsesor = c
+              ? c.full_name ??
+                (c.first_name && c.last_name
+                  ? `${c.first_name} ${c.last_name}`
+                  : c.username ?? "—")
+              : null
+            return {
+              id: String(item.id),
+              nombre: item.nombre_completo,
+              email: item.correo_electronico,
+              telefono: item.telefono,
+              departamento:
+                item.empresa_donde_labora_actualmente ?? "Sin Departamento",
+              estado: item.status || "No contactado",
+              ultimoCambio: item.updated_at ?? "N/A",
+              asesor_id: c?.id ?? null,
+              asesor: c ? { id: c.id, nombre: nombreAsesor } : null,
+            }
+          })
+          .sort((a: Prospecto, b: Prospecto) => {
+            const getTime = (d: string) => {
+              const t = new Date(d).getTime()
+              return isNaN(t) ? 0 : t
+            }
+            return getTime(b.ultimoCambio) - getTime(a.ultimoCambio)
+          })
         setProspectos(arr)
       })
       .catch(e => setError(e.message))

--- a/components/gestion/gestion-prospectos.tsx
+++ b/components/gestion/gestion-prospectos.tsx
@@ -110,6 +110,13 @@ export default function GestionProspectos() {
             ultimoCambio: item.updated_at ?? "N/A",
           }))
           .filter((p: any) => p.estado.toLowerCase() !== "preinscripción")
+          .sort((a: Prospecto, b: Prospecto) => {
+            const getTime = (d: string) => {
+              const t = new Date(d).getTime()
+              return isNaN(t) ? 0 : t
+            }
+            return getTime(b.ultimoCambio) - getTime(a.ultimoCambio)
+          })
         setProspectos(list)
       } catch (err: any) {
         setError(err.message || "Error inesperado")

--- a/components/inscripcion/registration-form.tsx
+++ b/components/inscripcion/registration-form.tsx
@@ -33,6 +33,7 @@ export default function RegistrationForm() {
   const [progress, setProgress] = useState(20)
   const [showModal, setShowModal] = useState(false)
   const [prospectoId, setProspectoId] = useState<number | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const [datosPersonales, setDatosPersonales] = useState<DatosPersonales>({
     nombre: "", paisOrigen: "", paisResidencia: "", telefono: "",
@@ -74,6 +75,8 @@ export default function RegistrationForm() {
   }
 
   const handleFinalizarInscripcion = async () => {
+    if (isSubmitting) return
+    setIsSubmitting(true)
     try {
       const response = await axios.post(
         `${API_BASE_URL}/api/inscripciones/finalizar`,
@@ -120,7 +123,7 @@ export default function RegistrationForm() {
           window.location.reload();
         }
       });
-  
+
     } catch (error: any) {
       console.error("Error al finalizar inscripción:", error.response?.data || error);
       Swal.fire({
@@ -128,17 +131,25 @@ export default function RegistrationForm() {
         text: error.response?.data?.message || "Ocurrió un error",
         icon: 'error',
       });
+    } finally {
+      setIsSubmitting(false)
     }
   };
   
   
 
   return (
-    <div className="container mx-auto max-w-6xl p-6">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-primary mb-2">Ficha de Inscripción</h1>
-        <Progress value={progress} className="h-2 w-full" />
-      </div>
+    <div className="relative">
+      {isSubmitting && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/60">
+          <Loader2 className="mr-2 h-6 w-6 animate-spin" /> Procesando...
+        </div>
+      )}
+      <div className="container mx-auto max-w-6xl p-6">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-primary mb-2">Ficha de Inscripción</h1>
+          <Progress value={progress} className="h-2 w-full" />
+        </div>
 
       <Card className="border-2 border-muted shadow-md">
         <CardContent className="p-6">
@@ -195,6 +206,7 @@ export default function RegistrationForm() {
                 setDocumentos={setDocumentos}
                 goPrev={() => changeTab("financiero")}
                 onFinalizar={handleFinalizarInscripcion}
+                isFinalizing={isSubmitting}
                 prospectoId={prospectoId as number}
               />
             </TabsContent>
@@ -232,6 +244,7 @@ export default function RegistrationForm() {
           setShowModal(false)
         }}
       />
+      </div>
     </div>
   )
 }

--- a/components/inscripcion/tabs/DocumentosTab.tsx
+++ b/components/inscripcion/tabs/DocumentosTab.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, useRef, useMemo, Dispatch, SetStateAction } from "react"
 import axios, { AxiosError } from "axios"
 import { API_BASE_URL } from "@/utils/apiConfig"
-import { ArrowLeft, ArrowRight, FileText, Info, Upload, X, CheckCircle } from "lucide-react"
+import { ArrowLeft, ArrowRight, FileText, Info, Upload, X, CheckCircle, Loader2 } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
@@ -35,6 +35,7 @@ type Props = {
   goPrev: () => void
   prospectoId: number
   onFinalizar?: () => Promise<void>
+  isFinalizing?: boolean
 }
 
 export default function DocumentosTab({
@@ -43,6 +44,7 @@ export default function DocumentosTab({
   goPrev,
   prospectoId,
   onFinalizar,
+  isFinalizing,
 }: Props) {
   const hiddenInput = useRef<HTMLInputElement>(null)
   const uploadTarget = useRef<string | null>(null)
@@ -207,11 +209,17 @@ export default function DocumentosTab({
 
         {onFinalizar ? (
           <Button
-            disabled={!isFormValid}
+            disabled={!isFormValid || isFinalizing}
             onClick={onFinalizar}
             className={isFormValid ? "bg-green-600 hover:bg-green-700 text-white w-full sm:w-auto" : "w-full sm:w-auto"}
           >
-            Finalizar inscripción <ArrowRight className="ml-2 h-4 w-4" />
+            {isFinalizing ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Finalizando...
+              </>
+            ) : (
+              <>Finalizar inscripción <ArrowRight className="ml-2 h-4 w-4" /></>
+            )}
           </Button>
         ) : (
           <Link href="/inscripcion/revision" className="w-full sm:w-auto">


### PR DESCRIPTION
## Summary
- show full-page loader when finalizing inscription
- keep latest prospects first in leads-asignados, seguimiento, correos and admin views

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: many type errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6888dd4c49a083289719afbeb41334d9