### PR TITLE
Add Moodle completados section

### DIFF
--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -10,6 +10,7 @@ import {
   unassignCourses,
 } from "@/services/students";
 import { fetchStudentCourses } from "@/services/courses";
+import { fetchAprobados, MoodleConsultaCourse } from "@/services/moodleConsultas";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -156,6 +157,7 @@ const DropZone = ({ status, onDrop, title, count, icon, children }: DropZoneProp
 export function StudentAssignmentView({ student, onCoursesChange }: StudentAssignmentViewProps) {
   const [assigned, setAssigned] = useState<Course[]>([]);
   const [completed, setCompleted] = useState<Course[]>([]);
+  const [moodleCompleted, setMoodleCompleted] = useState<MoodleConsultaCourse[]>([]);
   const [allCourses, setAllCourses] = useState<Course[]>([]);
   const [available, setAvailable] = useState<Course[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -210,6 +212,19 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
       );
     });
   }, [allCourses, assigned, completed]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (student.carnet) {
+          const data = await fetchAprobados(student.carnet);
+          setMoodleCompleted(Array.isArray(data) ? data : []);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+  }, [student.carnet]);
 
   useEffect(() => {
     setHasUnsavedChanges(pendingAssign.length > 0 || pendingUnassign.length > 0);
@@ -408,6 +423,37 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
               ) : (
                 filterCourses(completed).map((course) => (
                   <CourseCard key={course.id} course={course} status="completed" />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-lg flex items-center text-green-700">
+              <Award className="h-5 w-5 mr-2" />
+              Cursos Completados (Moodle)
+            </h3>
+            <Badge variant="outline" className="text-sm">
+              {moodleCompleted.length} cursos
+            </Badge>
+          </div>
+          <div className="min-h-[400px] p-6 rounded-lg border-2 border-solid border-green-200 bg-green-50">
+            <div className="space-y-3">
+              {moodleCompleted.length === 0 ? (
+                <div className="text-center py-12">
+                  <Award className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+                  <p className="text-gray-500">No hay cursos completados</p>
+                </div>
+              ) : (
+                moodleCompleted.map((course) => (
+                  <div key={course.courseid} className="border bg-white p-3 rounded flex justify-between items-center">
+                    <span>{course.coursename}</span>
+                    <Badge variant="secondary" className="ml-2 text-xs">
+                      {course.estado_curso}
+                    </Badge>
+                  </div>
                 ))
               )}
             </div>

--- a/services/moodleConsultas.ts
+++ b/services/moodleConsultas.ts
@@ -1,0 +1,23 @@
+import api from './api'
+
+export interface MoodleConsultaCourse {
+  courseid: number
+  coursename: string
+  estado_curso: string
+  [key: string]: any
+}
+
+export const fetchCursos = async (carnet: string): Promise<MoodleConsultaCourse[]> => {
+  const res = await api.get(`/moodle/consultas/${encodeURIComponent(carnet)}`)
+  return Array.isArray(res.data?.data) ? res.data.data : []
+}
+
+export const fetchAprobados = async (carnet: string): Promise<MoodleConsultaCourse[]> => {
+  const res = await api.get(`/moodle/consultas/aprobados/${encodeURIComponent(carnet)}`)
+  return Array.isArray(res.data?.data) ? res.data.data : []
+}
+
+export const fetchReprobados = async (carnet: string): Promise<MoodleConsultaCourse[]> => {
+  const res = await api.get(`/moodle/consultas/reprobados/${encodeURIComponent(carnet)}`)
+  return Array.isArray(res.data?.data) ? res.data.data : []
+}


### PR DESCRIPTION
## Summary
- add service wrapper for Moodle consulta endpoints
- fetch courses aprobados for selected student
- show Moodle completed courses section in assignment view

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'next/navigation' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688a4dae1aa08328afa6e0e8b576e580