### PR TITLE
Improve bulk assignment filtering

### DIFF
--- a/components/bulk-assignment-panel.tsx
+++ b/components/bulk-assignment-panel.tsx
@@ -33,14 +33,29 @@ export function BulkAssignmentPanel({
   const [filterArea, setFilterArea] = useState<string>("all")
   const [filterProgram, setFilterProgram] = useState<string>("all")
 
+  const programIds = useMemo(
+    () => Array.from(new Set(selectedStudents.map((s) => s.programId).filter(Boolean))),
+    [selectedStudents]
+  )
+
+  const dedupedCourses = useMemo(() => {
+    const uniq = new Map<string | number, Course>()
+    courses.forEach((c) => uniq.set(c.id, c))
+    const list = Array.from(uniq.values())
+    if (programIds.length <= 1) return list
+    return list.filter((c) =>
+      programIds.every((pid) => c.programIds.includes(pid))
+    )
+  }, [courses, programIds])
+
   const programOptions = useMemo(() => {
-    const names = courses.flatMap((c) =>
+    const names = dedupedCourses.flatMap((c) =>
       Array.isArray(c.programas) ? c.programas.map((p) => p.nombre_del_programa) : []
     )
     return Array.from(new Set(names))
-  }, [courses])
+  }, [dedupedCourses])
 
-  const filteredCourses = courses.filter((course) => {
+  const filteredCourses = dedupedCourses.filter((course) => {
     const matchesSearch =
       course.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
       course.code.toLowerCase().includes(searchTerm.toLowerCase())
@@ -136,9 +151,7 @@ export function BulkAssignmentPanel({
           <div className="flex flex-wrap gap-2">
             {selectedStudents.map((student) => (
               <Badge key={student.id} variant="secondary">
-                {student.name}
-                {" "}
-                {student.program ? `(${student.program})` : ""}
+                {student.name} - {student.carnet} - {student.specialty}
               </Badge>
             ))}
           </div>

--- a/services/courses.ts
+++ b/services/courses.ts
@@ -98,13 +98,16 @@ export const fetchStudentCourses = async (studentId: string): Promise<Course[]> 
   const res = await api.get(`/estudiante-programa/${studentId}/with-courses`)
   const data = Array.isArray(res.data) ? res.data : res.data.data
   const courses: Course[] = []
+  const unique = new Map<number, Course>()
   data.forEach((ep: any) => {
     if (ep.programa && Array.isArray(ep.programa.courses)) {
       ep.programa.courses.forEach((c: any) => {
-        courses.push(mapCourseFromApi(c))
+        const mapped = mapCourseFromApi(c)
+        unique.set(mapped.id, mapped)
       })
     }
   })
+  unique.forEach((c) => courses.push(c))
   return courses
 }
 
@@ -162,5 +165,6 @@ export const getAvailableCoursesForStudents = async (
     params: { prospecto_ids: prospectoIds.map(Number) },
   })
   const data = Array.isArray(res.data) ? res.data : res.data.data
-  return data.map(mapCourseFromApi)
+  const mapped = data.map(mapCourseFromApi)
+  return Array.from(new Map(mapped.map((c) => [c.id, c])).values())
 }


### PR DESCRIPTION
## Summary
- refine deduplication of student courses and available courses
- filter bulk assignment courses by shared programs
- display selected students with carnet and career code

## Testing
- `npm run lint` *(fails: prompts for initial configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688a519b3d2c8328b20893fe4ab888cb