### PR TITLE
Add Moodle approved course support

### DIFF
--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -10,6 +10,7 @@ import {
   unassignCourses,
 } from "@/services/students";
 import { fetchStudentCourses } from "@/services/courses";
+import fetchApprovedMoodleCourses, { MoodleQueryCourse } from "@/services/moodleCourseQueries";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -171,12 +172,39 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
   useEffect(() => {
     (async () => {
       try {
-        const [lists, courses] = await Promise.all([
+        const [lists, courses, moodle] = await Promise.all([
           fetchStudentCourseLists(student.id),
           fetchStudentCourses(student.id),
+          fetchApprovedMoodleCourses(student.carnet),
         ]);
+
+        const pensumNames = courses.map((c) => c.name.toLowerCase());
+        const filteredMoodle = moodle.filter((m) => {
+          const name = m.coursename.toLowerCase();
+          return !pensumNames.some(
+            (p) => name.includes(p) || p.includes(name),
+          );
+        });
+
+        const mappedMoodle: Course[] = filteredMoodle.map((m) => ({
+          id: 1000000 + m.courseid,
+          name: m.coursename,
+          code: String(m.courseid),
+          area: 'common',
+          credits: 0,
+          startDate: m.fecha_inicio_curso,
+          endDate: m.fecha_fin_curso,
+          schedule: '',
+          duration: '',
+          programIds: [],
+          facilitatorId: null,
+          status: 'synced',
+          facilitator: null,
+          programas: [],
+        }));
+
         setAssigned(lists.assigned);
-        setCompleted(lists.completed);
+        setCompleted([...lists.completed, ...mappedMoodle]);
         setAllCourses(courses);
       } catch (err) {
         console.error(err);
@@ -184,7 +212,7 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
         setIsLoading(false);
       }
     })();
-  }, [student.id, student.programId]);
+  }, [student.id, student.programId, student.carnet]);
 
   useEffect(() => {
     const avail = allCourses.filter(

--- a/services/moodleCourseQueries.ts
+++ b/services/moodleCourseQueries.ts
@@ -1,0 +1,21 @@
+import api from './api'
+
+export interface MoodleQueryCourse {
+  userid: number
+  carnet: string
+  fullname: string
+  courseid: number
+  coursename: string
+  fecha_inicio_curso: string
+  fecha_fin_curso: string
+  finalgrade: number | null
+  estado_curso: string
+}
+
+export const fetchApprovedMoodleCourses = async (carnet: string): Promise<MoodleQueryCourse[]> => {
+  const res = await api.get(`/moodle/consultas/aprobados/${carnet}`)
+  const data = Array.isArray(res.data.data) ? res.data.data : res.data
+  return data as MoodleQueryCourse[]
+}
+
+export default fetchApprovedMoodleCourses


### PR DESCRIPTION
## Summary
- add new `fetchApprovedMoodleCourses` service
- fetch Moodle courses in `StudentAssignmentView` and merge into completed list

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run build` *(fails: cannot download fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688a68e295fc83289d2640a4b00cc14e