### PR TITLE
Add moodle course cards

### DIFF
--- a/components/views/student-assignment-view.tsx
+++ b/components/views/student-assignment-view.tsx
@@ -10,6 +10,9 @@ import {
   unassignCourses,
 } from "@/services/students";
 import { fetchStudentCourses } from "@/services/courses";
+import fetchApprovedMoodleCourses, {
+  MoodleQueryCourse,
+} from "@/services/moodleCourseQueries";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -23,6 +26,39 @@ import {
   User,
   X,
 } from "lucide-react";
+
+const normalizeName = (str: string) =>
+  str
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]/g, "");
+
+const levenshtein = (a: string, b: string) => {
+  const matrix: number[][] = Array.from({ length: b.length + 1 }, () => []);
+  for (let i = 0; i <= b.length; i++) matrix[i][0] = i;
+  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      const cost = a[j - 1] === b[i - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost,
+      );
+    }
+  }
+  return matrix[b.length][a.length];
+};
+
+const areNamesSimilar = (a: string, b: string) => {
+  const na = normalizeName(a);
+  const nb = normalizeName(b);
+  if (na.includes(nb) || nb.includes(na)) return true;
+  const distance = levenshtein(na, nb);
+  const ratio = distance / Math.max(na.length, nb.length);
+  return ratio <= 0.3;
+};
 
 interface StudentAssignmentViewProps {
   student: Student;
@@ -101,6 +137,31 @@ const CourseCard = ({ course, status }: CourseCardProps) => {
   );
 };
 
+interface MoodleCourseCardProps {
+  course: MoodleQueryCourse;
+}
+
+const MoodleCourseCard = ({ course }: MoodleCourseCardProps) => (
+  <Card className="border-green-200 bg-green-50">
+    <CardContent className="p-4 space-y-1">
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex items-center space-x-2">
+          <Award className="h-4 w-4 text-green-600" />
+          <span className="font-medium">{course.coursename}</span>
+        </div>
+        <Badge className="bg-green-600 text-white text-xs">Moodle</Badge>
+      </div>
+      <p className="text-sm text-gray-600">Código: {course.courseid}</p>
+      <p className="text-sm text-gray-600">Inicio: {course.fecha_inicio_curso}</p>
+      <p className="text-sm text-gray-600">Fin: {course.fecha_fin_curso}</p>
+      <p className="text-sm text-gray-600">
+        Nota final: {course.finalgrade ?? 'N/A'}
+      </p>
+      <p className="text-xs text-gray-500">Datos extraídos de Moodle</p>
+    </CardContent>
+  </Card>
+);
+
 interface DropZoneProps {
   status: "assigned" | "available";
   onDrop: (course: Course, to: "assigned" | "available") => void;
@@ -156,6 +217,7 @@ const DropZone = ({ status, onDrop, title, count, icon, children }: DropZoneProp
 export function StudentAssignmentView({ student, onCoursesChange }: StudentAssignmentViewProps) {
   const [assigned, setAssigned] = useState<Course[]>([]);
   const [completed, setCompleted] = useState<Course[]>([]);
+  const [moodleCompleted, setMoodleCompleted] = useState<MoodleQueryCourse[]>([]);
   const [allCourses, setAllCourses] = useState<Course[]>([]);
   const [available, setAvailable] = useState<Course[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -171,12 +233,22 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
   useEffect(() => {
     (async () => {
       try {
-        const [lists, courses] = await Promise.all([
+        const [lists, courses, moodle] = await Promise.all([
           fetchStudentCourseLists(student.id),
           fetchStudentCourses(student.id),
+          fetchApprovedMoodleCourses(student.carnet),
         ]);
+
+        console.log('[DEBUG] Cursos aprobados de Moodle:', moodle);
+
+        const pensumNames = courses.map((c) => c.name);
+        const filteredMoodle = moodle.filter(
+          (m) => !pensumNames.some((p) => areNamesSimilar(m.coursename, p)),
+        );
+
         setAssigned(lists.assigned);
         setCompleted(lists.completed);
+        setMoodleCompleted(filteredMoodle);
         setAllCourses(courses);
       } catch (err) {
         console.error(err);
@@ -184,17 +256,18 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
         setIsLoading(false);
       }
     })();
-  }, [student.id, student.programId]);
+  }, [student.id, student.programId, student.carnet]);
 
   useEffect(() => {
     const avail = allCourses.filter(
       (c) =>
         c.status !== 'synced' &&
         !assigned.some((a) => a.id === c.id) &&
-        !completed.some((co) => co.id === c.id),
+        !completed.some((co) => co.id === c.id) &&
+        !moodleCompleted.some((m) => m.courseid === c.id),
     );
     setAvailable(avail);
-  }, [allCourses, assigned, completed]);
+  }, [allCourses, assigned, completed, moodleCompleted]);
 
   const monthCourses = useMemo(() => {
     const now = new Date();
@@ -206,10 +279,11 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
         d >= start &&
         d <= end &&
         !assigned.some((a) => a.id === c.id) &&
-        !completed.some((co) => co.id === c.id)
+        !completed.some((co) => co.id === c.id) &&
+        !moodleCompleted.some((m) => m.courseid === c.id)
       );
     });
-  }, [allCourses, assigned, completed]);
+  }, [allCourses, assigned, completed, moodleCompleted]);
 
   useEffect(() => {
     setHasUnsavedChanges(pendingAssign.length > 0 || pendingUnassign.length > 0);
@@ -270,6 +344,19 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
     [searchTerm],
   );
 
+  const filterMoodleCourses = useCallback(
+    (list: MoodleQueryCourse[]) => {
+      const term = searchTerm.trim().toLowerCase();
+      if (!term) return list;
+      return list.filter(
+        (c) =>
+          c.coursename.toLowerCase().includes(term) ||
+          String(c.courseid).includes(term),
+      );
+    },
+    [searchTerm],
+  );
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -308,7 +395,7 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
             </div>
             <div>
               <span className="font-medium text-gray-600">Cursos Completados:</span>
-              <p className="text-gray-900">{completed.length}</p>
+              <p className="text-gray-900">{completed.length + moodleCompleted.length}</p>
             </div>
           </div>
         </CardContent>
@@ -395,20 +482,25 @@ export function StudentAssignmentView({ student, onCoursesChange }: StudentAssig
               Cursos Completados
             </h3>
             <Badge variant="outline" className="text-sm">
-              {completed.length} cursos
+              {completed.length + moodleCompleted.length} cursos
             </Badge>
           </div>
           <div className="min-h-[400px] p-6 rounded-lg border-2 border-solid border-green-200 bg-green-50">
             <div className="space-y-3">
-              {filterCourses(completed).length === 0 ? (
+              {filterCourses(completed).length === 0 && filterMoodleCourses(moodleCompleted).length === 0 ? (
                 <div className="text-center py-12">
                   <Award className="h-12 w-12 text-gray-300 mx-auto mb-4" />
                   <p className="text-gray-500">No hay cursos completados</p>
                 </div>
               ) : (
-                filterCourses(completed).map((course) => (
-                  <CourseCard key={course.id} course={course} status="completed" />
-                ))
+                <>
+                  {filterCourses(completed).map((course) => (
+                    <CourseCard key={course.id} course={course} status="completed" />
+                  ))}
+                  {filterMoodleCourses(moodleCompleted).map((course) => (
+                    <MoodleCourseCard key={course.courseid} course={course} />
+                  ))}
+                </>
               )}
             </div>
           </div>

--- a/services/moodleCourseQueries.ts
+++ b/services/moodleCourseQueries.ts
@@ -1,0 +1,21 @@
+import api from './api'
+
+export interface MoodleQueryCourse {
+  userid: number
+  carnet: string
+  fullname: string
+  courseid: number
+  coursename: string
+  fecha_inicio_curso: string
+  fecha_fin_curso: string
+  finalgrade: number | null
+  estado_curso: string
+}
+
+export const fetchApprovedMoodleCourses = async (carnet: string): Promise<MoodleQueryCourse[]> => {
+  const res = await api.get(`/moodle/consultas/aprobados/${carnet}`)
+  const data = Array.isArray(res.data.data) ? res.data.data : res.data
+  return data as MoodleQueryCourse[]
+}
+
+export default fetchApprovedMoodleCourses


### PR DESCRIPTION
## Summary
- integrate Moodle courses with similarity checks
- display Moodle course cards in completed list
- show total completed count including Moodle data

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: cannot fetch fonts & compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a68e295fc83289d2640a4b00cc14e