### PR TITLE
Fix missing hook import causing build failure

### DIFF
--- a/components/finanzas/subir-boleta.tsx
+++ b/components/finanzas/subir-boleta.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"


### PR DESCRIPTION
## Summary
- import `useEffect` in the financial receipt uploader component

## Testing
- `npm run lint` *(fails: prompts for interactive configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688be4aced7083288b649a2b739eb6b5