### PR TITLE
feat: add lead origin management

### DIFF
--- a/components/captura/captura-prospectos.tsx
+++ b/components/captura/captura-prospectos.tsx
@@ -76,6 +76,7 @@ export default function CapturaProspectos() {
   const [empresas, setEmpresas] = useState<{ id: number; nombre: string; descripcion: string | null; activo: boolean }[]>([])
 
   const [showOtherCompany, setShowOtherCompany] = useState(false);
+  const [showOtherOrigin, setShowOtherOrigin] = useState(false);
 
   // useForm con defaultValues para país=1 (Guatemala)
   const form = useForm<FormData>({
@@ -424,7 +425,18 @@ export default function CapturaProspectos() {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>Origen</FormLabel>
-                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <Select
+                        onValueChange={(value) => {
+                          if (value === "otros") {
+                            setShowOtherOrigin(true);
+                            field.onChange("");
+                          } else {
+                            setShowOtherOrigin(false);
+                            field.onChange(value);
+                          }
+                        }}
+                        value={showOtherOrigin ? "otros" : field.value}
+                      >
                         <FormControl>
                           <SelectTrigger>
                             <SelectValue placeholder="Seleccione el origen" />
@@ -443,12 +455,29 @@ export default function CapturaProspectos() {
                             Actividades de Escritorio
                           </SelectItem>
                           <SelectItem value="Meeting">Meeting</SelectItem>
+                          <SelectItem value="otros">Otros</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
+
+                {showOtherOrigin && (
+                  <FormField
+                    control={form.control}
+                    name="Origen"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Especifique el origen</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Ingrese el origen" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
               </div>
 
               {/* Notas generales */}

--- a/components/gestion/gestion-prospectos.tsx
+++ b/components/gestion/gestion-prospectos.tsx
@@ -34,6 +34,7 @@ interface Prospecto {
   departamento: string
   puesto: string
   estado: string
+  origen?: string
   observaciones?: string
   ultimoCambio: string
 }
@@ -52,6 +53,7 @@ export default function GestionProspectos() {
   const [estadoFilter, setEstadoFilter] = useState<string>("todos")
   const [departamentoFilter, setDepartamentoFilter] = useState<string>("todos")
   const [puestoFilter, setPuestoFilter] = useState<string>("todos")
+  const [origenFilter, setOrigenFilter] = useState<string>("todos")
   const [pageSize, setPageSize] = useState<string>("5")
   const [currentPage, setCurrentPage] = useState<number>(1)
 
@@ -76,6 +78,17 @@ export default function GestionProspectos() {
           prospectos
             .map((p) => p.puesto)
             .filter((p) => p && p.trim() !== "")
+        )
+      ),
+    [prospectos]
+  )
+  const origenes = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          prospectos
+            .map((p) => p.origen)
+            .filter((o) => o && o.trim() !== "")
         )
       ),
     [prospectos]
@@ -106,6 +119,7 @@ export default function GestionProspectos() {
               item.empresa_donde_labora_actualmente ?? "Sin Departamento",
             puesto: item.puesto ?? "—",
             estado: item.status || "No contactado",
+            origen: item.medio_conocimiento_institucion ?? "—",
             observaciones: item.observaciones ?? "",
             ultimoCambio: item.updated_at ?? "N/A",
           }))
@@ -168,11 +182,14 @@ export default function GestionProspectos() {
         departamentoFilter === "todos" || p.departamento === departamentoFilter
       const matchesPuesto =
         puestoFilter === "todos" || p.puesto === puestoFilter
+      const matchesOrigen =
+        origenFilter === "todos" || p.origen === origenFilter
       return (
         matchesSearch &&
         matchesEstado &&
         matchesDepartamento &&
-        matchesPuesto
+        matchesPuesto &&
+        matchesOrigen
       )
     })
   }, [
@@ -181,6 +198,7 @@ export default function GestionProspectos() {
     estadoFilter,
     departamentoFilter,
     puestoFilter,
+    origenFilter,
   ])
 
   // Paginación
@@ -364,6 +382,25 @@ export default function GestionProspectos() {
             ))}
           </SelectContent>
         </Select>
+        <Select
+          value={origenFilter}
+          onValueChange={(v) => {
+            setOrigenFilter(v)
+            setCurrentPage(1)
+          }}
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Origen" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="todos">Todos</SelectItem>
+            {origenes.map((o) => (
+              <SelectItem key={o} value={o}>
+                {o}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
         <Button variant="outline">
           <Filter className="h-4 w-4 mr-2" />
@@ -399,6 +436,7 @@ export default function GestionProspectos() {
               <th className="py-3 px-4 text-left">Teléfono</th>
               <th className="py-3 px-4 text-left">Empresa</th>
               <th className="py-3 px-4 text-left">Puesto</th>
+              <th className="py-3 px-4 text-left">Origen</th>
               <th className="py-3 px-4 text-left">Estado</th>
               <th className="py-3 px-4 text-left">Acciones</th>
             </tr>
@@ -414,10 +452,11 @@ export default function GestionProspectos() {
                 </td>
                 <td className="py-3 px-4">{p.nombre}</td>
                 <td className="py-3 px-4">{p.email}</td>
-                <td className="py-3 px-4">{p.telefono}</td>
-                <td className="py-3 px-4">{p.departamento}</td>
-                <td className="py-3 px-4">{p.puesto}</td>
-                <td className="py-3 px-4">
+              <td className="py-3 px-4">{p.telefono}</td>
+              <td className="py-3 px-4">{p.departamento}</td>
+              <td className="py-3 px-4">{p.puesto}</td>
+              <td className="py-3 px-4">{p.origen}</td>
+              <td className="py-3 px-4">
                   <div className="flex flex-col">
                     <span
                       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getEstadoColor(


### PR DESCRIPTION
## Summary
- show and filter lead origin in prospect management
- allow manual lead origin entry in individual capture form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68926c1c58a48328a7021c5b99fa68de