### PR TITLE
Reorder prospect management link in sidebars

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -163,20 +163,20 @@ export default function Sidebar({ open, className }: SidebarProps) {
             <div className="pl-6 text-sm space-y-1 mt-1 mb-2">
               {/* Links visibles para Administradores y Asesores */}
               <Link
-                href="/gestion"
-                className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/gestion" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
-                  } transition-colors duration-200`}
-              >
-                <Users size={16} className="mr-2" />
-                <span>Gestión de Prospectos</span>
-              </Link>
-              <Link
                 href="/captura"
                 className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/captura" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
                   } transition-colors duration-200`}
               >
                 <Plus size={16} className="mr-2" />
                 <span>Captura de Prospectos</span>
+              </Link>
+              <Link
+                href="/gestion"
+                className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/gestion" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
+                  } transition-colors duration-200`}
+              >
+                <Users size={16} className="mr-2" />
+                <span>Gestión de Prospectos</span>
               </Link>
               <Link
                 href="/leads-asignados"

--- a/components/layout/sidebar2.tsx
+++ b/components/layout/sidebar2.tsx
@@ -163,20 +163,20 @@ export default function Sidebar({ open, className }: SidebarProps) {
             <div className="pl-6 text-sm space-y-1 mt-1 mb-2">
               {/* Links visibles para Administradores y Asesores */}
               <Link
-                href="/gestion"
-                className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/gestion" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
-                  } transition-colors duration-200`}
-              >
-                <Users size={16} className="mr-2" />
-                <span>Gestión de Prospectos</span>
-              </Link>
-              <Link
                 href="/captura"
                 className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/captura" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
                   } transition-colors duration-200`}
               >
                 <Plus size={16} className="mr-2" />
                 <span>Captura de Prospectos</span>
+              </Link>
+              <Link
+                href="/gestion"
+                className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/gestion" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
+                  } transition-colors duration-200`}
+              >
+                <Users size={16} className="mr-2" />
+                <span>Gestión de Prospectos</span>
               </Link>
               <Link
                 href="/leads-asignados"

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -113,13 +113,13 @@ export default function Sidebar({ open, className }: SidebarProps) {
               </button>
               {expandedSections.prospectos && (
                 <div className="pl-10 text-sm space-y-1">
-                  <Link href="/gestion" className={linkClass("/gestion")}>
-                    <Users size={16} className="mr-2" />
-                    Gestión de Prospectos
-                  </Link>
                   <Link href="/captura" className={linkClass("/captura")}>
                     <Plus size={16} className="mr-2" />
                     Captura de Prospectos
+                  </Link>
+                  <Link href="/gestion" className={linkClass("/gestion")}>
+                    <Users size={16} className="mr-2" />
+                    Gestión de Prospectos
                   </Link>
                   <Link href="/leads-asignados" className={linkClass("/leads-asignados")}>
                     <FileText size={16} className="mr-2" />


### PR DESCRIPTION
## Summary
- Move "Gestión de Prospectos" below "Captura de Prospectos" in all sidebar variants

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce64baec8328a5781f68963715a2