### PR TITLE
fix: ensure calendar weeks start on Sunday

### DIFF
--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -9,10 +9,17 @@ import { buttonVariants } from "@/components/ui/button"
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>
 
-function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  weekStartsOn = 0,
+  ...props
+}: CalendarProps) {
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
+      weekStartsOn={weekStartsOn}
       className={cn("p-3", className)}
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",


### PR DESCRIPTION
## Summary
- default Calendar component to start weeks on Sunday for proper weekday alignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6892e7157b948328ae6ee5667ee7bc37