### PR TITLE
feat: allow resubmitting rejected documents

### DIFF
--- a/app/academico/documentos-rechazados/page.tsx
+++ b/app/academico/documentos-rechazados/page.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/use-toast"
+import api from "@/services/api"
+
+interface ProspectDocument {
+  id: number
+  tipo_documento: string
+  estado: string
+  updated_at: string
+}
+
+export default function RejectedDocumentsPage() {
+  const [documents, setDocuments] = useState<ProspectDocument[]>([])
+  const [selected, setSelected] = useState<ProspectDocument | null>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+  const { toast } = useToast()
+
+  useEffect(() => {
+    const fetchDocuments = async () => {
+      try {
+        const res = await api.get("/documentos")
+        const rejected = res.data.filter((doc: ProspectDocument) => doc.estado === "rechazado")
+        setDocuments(rejected)
+      } catch (error) {
+        console.error(error)
+        toast({ title: "Error", description: "No se pudieron cargar los documentos" })
+      }
+    }
+    fetchDocuments()
+  }, [toast])
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0])
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!selected || !file) return
+    const formData = new FormData()
+    formData.append("file", file)
+    formData.append("estado", "pendiente")
+    try {
+      setLoading(true)
+      const res = await api.patch(`/documentos/${selected.id}`, formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      })
+      toast({ title: "Documento reenviado" })
+      setDocuments((prev) => prev.filter((d) => d.id !== selected.id))
+      setSelected(null)
+      setFile(null)
+    } catch (error) {
+      console.error(error)
+      toast({ title: "Error", description: "No se pudo reenviar el documento" })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Reenvío de Documentos Rechazados</h1>
+      {documents.length === 0 ? (
+        <p className="text-gray-500">No hay documentos rechazados.</p>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {documents.map((doc) => (
+            <Card key={doc.id}>
+              <CardHeader>
+                <CardTitle className="flex justify-between items-center">
+                  {doc.tipo_documento}
+                  <span className="text-sm font-normal capitalize text-red-600">{doc.estado}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-gray-600">Última actualización: {new Date(doc.updated_at).toLocaleDateString()}</p>
+              </CardContent>
+              <CardFooter>
+                <Button onClick={() => setSelected(doc)}>Subir corrección</Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={!!selected} onOpenChange={() => { setSelected(null); setFile(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reenviar {selected?.tipo_documento}</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <Input type="file" accept=".pdf,.jpg,.jpeg,.png" onChange={handleFileChange} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setSelected(null); setFile(null); }} disabled={loading}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSubmit} disabled={!file || loading}>
+              {loading ? "Enviando..." : "Enviar corrección"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -409,6 +409,14 @@ export default function Sidebar({ open, className }: SidebarProps) {
                   <UserCheck size={16} className="mr-2" />
                   <span>Estatus Académico</span>
                 </Link>
+                <Link
+                  href="/academico/documentos-rechazados"
+                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/documentos-rechazados" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"`
+                    } transition-colors duration-200`}
+                >
+                  <RefreshCw size={16} className="mr-2" />
+                  <span>Docs Rechazados</span>
+                </Link>
                 {/* <Link
                   href="/academico/estado-sistema"
                   className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/estado-sistema" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"


### PR DESCRIPTION
## Summary
- add page under Académico for resubmitting rejected prospect documents
- link new screen from sidebar for quick access

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for interactive config)


------
https://chatgpt.com/codex/tasks/task_e_6893c4f33a988328bb1c28e84651c32a