### PR TITLE
feat: require corporate email and generalize ID field

### DIFF
--- a/components/inscripcion/tabs/PersonalTab.tsx
+++ b/components/inscripcion/tabs/PersonalTab.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import { useMemo, useEffect, useState } from "react"
+import { useMemo, useEffect } from "react"
 import { Search, ArrowRight, CheckCircle } from "lucide-react"
-import Swal from "sweetalert2"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -11,6 +10,12 @@ import CountryCombobox from "../CountryCombobox"
 import { Label } from "@/components/ui/label"
 import { RequiredAsterisk } from "@/components/ui/required-asterisk"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { DatosPersonales } from "../types"
 import { useCountries } from "@/hooks/useCountries"
 
@@ -42,34 +47,24 @@ export default function PersonalTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [countries])
 
-  // Validación de campos obligatorios con DPI de 13 dígitos
+  // Validación de campos obligatorios con número de identificación alfanumérico
   const isFormValid = useMemo(() => {
-    const dpi = datos.dpi ?? ""
+    const dpi = (datos.dpi ?? "").trim()
     return (
       (datos.nombre ?? "").trim() !== "" &&
       datos.paisOrigen !== "" &&
       datos.paisResidencia !== "" &&
       (datos.telefono ?? "").trim() !== "" &&
-      /^\d{13}$/.test(dpi) &&
+      /^[A-Za-z0-9]+$/.test(dpi) &&
       (datos.emailPersonal ?? "").trim() !== "" &&
+      (datos.emailCorporativo ?? "").trim() !== "" &&
       datos.fechaNacimiento !== "" &&
       (datos.direccion ?? "").trim() !== ""
     )
   }, [datos])
 
-  // Función para validar DPI al salir del campo
-  const validateDpi = (value: string) => {
-    if (value && !/^\d{13}$/.test(value)) {
-      Swal.fire({
-        title: "DPI inválido",
-        text: "El DPI debe contener exactamente 13 dígitos numéricos.",
-        icon: "error",
-      })
-    }
-  }
-
   return (
-    <>
+    <TooltipProvider>
       {/* Botón búsqueda de prospecto */}
       <div className="mb-4 flex justify-start">
         <Button variant="outline" onClick={openModal}>
@@ -140,17 +135,22 @@ export default function PersonalTab({
           />
         </div>
 
-        {/* DPI con validación onBlur */}
+        {/* DPI/Identificación */}
         <div className="space-y-2">
           <Label>
-            DPI <RequiredAsterisk />
+            DPI/Identificación <RequiredAsterisk />
           </Label>
           <Input
             value={datos.dpi || ""}
             onChange={(e) => setDatos({ ...datos, dpi: e.target.value })}
-            onBlur={(e) => validateDpi(e.target.value)}
             required
           />
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{(datos.dpi || "").length} caracteres</span>
+            {datos.dpi && datos.dpi.length === 13 && /^\d{13}$/.test(datos.dpi) && (
+              <span className="text-green-600">DPI válido</span>
+            )}
+          </div>
         </div>
 
         {/* Emails */}
@@ -168,9 +168,16 @@ export default function PersonalTab({
           />
         </div>
         <div className="space-y-2">
-          <Label>
-            Email corporativo <RequiredAsterisk />
-          </Label>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Label>
+                Email corporativo <RequiredAsterisk />
+              </Label>
+            </TooltipTrigger>
+            <TooltipContent>
+              Si no cuentas con un correo corporativo, ingresa tu correo personal. Podrás actualizarlo después.
+            </TooltipContent>
+          </Tooltip>
           <Input
             type="email"
             value={datos.emailCorporativo || ""}
@@ -222,6 +229,6 @@ export default function PersonalTab({
           <ArrowRight className="ml-2 h-4 w-4" />
         </Button>
       </div>
-    </>
+    </TooltipProvider>
   )
 }


### PR DESCRIPTION
## Summary
- require corporate email and add tooltip guidance
- rename identification field to "DPI/Identificación" with alphanumeric validation and character counter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6893c4194c64832893782ab5f744a8d6