### PR TITLE
fix: update document resend method

### DIFF
--- a/app/academico/documentos-rechazados/page.tsx
+++ b/app/academico/documentos-rechazados/page.tsx
@@ -55,7 +55,7 @@ export default function RejectedDocumentsPage() {
     formData.append("estado", "pendiente")
     try {
       setLoading(true)
-      const res = await api.patch(`/documentos/${selected.id}`, formData, {
+      await api.put(`/documentos/${selected.id}`, formData, {
         headers: { "Content-Type": "multipart/form-data" },
       })
       toast({ title: "Documento reenviado" })


### PR DESCRIPTION
## Summary
- fix re-send of rejected documents by using `PUT` request

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires manual ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6894263d276c8328a3c6566a337754e6