### PR TITLE
refactor: move rejected docs to inscripcion

### DIFF
--- a/app/inscripcion/documentos-rechazados/page.tsx
+++ b/app/inscripcion/documentos-rechazados/page.tsx
@@ -55,7 +55,7 @@ export default function RejectedDocumentsPage() {
     formData.append("estado", "pendiente")
     try {
       setLoading(true)
-      const res = await api.patch(`/documentos/${selected.id}`, formData, {
+      await api.put(`/documentos/${selected.id}`, formData, {
         headers: { "Content-Type": "multipart/form-data" },
       })
       toast({ title: "Documento reenviado" })

--- a/components/inscripcion/archibobas.tsx
+++ b/components/inscripcion/archibobas.tsx
@@ -115,7 +115,7 @@ export function GestionFichas() {
   }
 
   const handleSolicitarCorreccion = () => {
-    if (selectedFicha && comentarioRevision.trim() !== "") {
+    if (selectedFicha) {
       // Aquí iría la lógica para enviar la solicitud de corrección
       setShowSuccessMessage(true)
       setTimeout(() => {

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -410,8 +410,8 @@ export default function Sidebar({ open, className }: SidebarProps) {
                   <span>Estatus Académico</span>
                 </Link>
                 <Link
-                  href="/academico/documentos-rechazados"
-                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/documentos-rechazados" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"} transition-colors duration-200`}
+                  href="/inscripcion/documentos-rechazados"
+                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/inscripcion/documentos-rechazados" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"} transition-colors duration-200`}
                 >
                   <RefreshCw size={16} className="mr-2" />
                   <span>Docs Rechazados</span>


### PR DESCRIPTION
## Summary
- move rejected documents page into inscripcion module
- drop required comment validation when requesting corrections
- adjust sidebar link to new route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6894263d276c8328a3c6566a337754e6