### PR TITLE
Consume full prospect data from unified API

### DIFF
--- a/components/inscripcion/gestion-fichas.tsx
+++ b/components/inscripcion/gestion-fichas.tsx
@@ -37,10 +37,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { Badge } from "@/components/ui/badge"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
-import { FichaEstudiante } from "@/components/inscripcion/types"
 import FichaDetalleModal from "@/components/inscripcion/modal/FichaDetalleModal"
 import { API_BASE_URL } from "@/utils/apiConfig"
+import { ProspectoDetalle } from "@/types/prospecto"
+import { getProspectos } from "@/services/prospectoService"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || API_BASE_URL
 const CONTEO_REVISADAS_KEY = "fichasRevisadasCount"
@@ -54,13 +54,13 @@ function incrementarRevisadas() {
 }
 
 export function GestionFichas() {
-  const [fichas, setFichas] = useState<FichaEstudiante[]>([])
+  const [fichas, setFichas] = useState<ProspectoDetalle[]>([])
   const [searchTerm, setSearchTerm] = useState("")
   const [filtroEstado, setFiltroEstado] = useState<string>("todos")
   const [filtroPrioridad, setFiltroPrioridad] = useState<string>("todas")
   const [filtroPeriodo, setFiltroPeriodo] = useState<string>("todos")
 
-  const [selectedFicha, setSelectedFicha] = useState<FichaEstudiante | null>(null)
+  const [selectedFicha, setSelectedFicha] = useState<ProspectoDetalle | null>(null)
   const [activeTab, setActiveTab] = useState<"fichas" | "documentos">("fichas")
   const [isDetalleModalOpen, setDetalleModalOpen] = useState(false)
   const [processingId, setProcessingId] = useState<number | null>(null)
@@ -68,56 +68,20 @@ export function GestionFichas() {
   useEffect(() => {
     async function fetchFichas() {
       try {
-        const res = await fetch(
-          `${API_URL}/prospectos/fichas/pendientes-public`,
-          { headers: { Accept: "application/json" } }
-        )
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const { data } = await res.json()
-        const mapped: FichaEstudiante[] = data.map((raw: any) => ({
-          id: raw.id,
-          nombre: raw.nombre_completo,
-          telefono: raw.telefono,
-          correo: raw.correo,
-          departamento: raw.departamento,
-          programa: raw.nombre_programa,
-          fecha: raw.created_at?.split("T")[0] ?? "",
-          estado: raw.status,
-          prioridad: (raw.prioridad as "alta" | "media" | "baja") || "media",
-          ultimaActualizacion: raw.updated_at ?? "",
-          documentos: [],
-        }))
-        setFichas(mapped)
+        const data = await getProspectos('pendiente')
+        setFichas(data)
       } catch (err) {
-        console.error("Error cargando fichas:", err)
-        Swal.fire("Error", "No se pudieron cargar las fichas", "error")
+        console.error('Error cargando fichas:', err)
+        Swal.fire('Error', 'No se pudieron cargar las fichas', 'error')
       }
     }
     fetchFichas()
   }, [])
 
-  const handleViewDetalle = async (f: FichaEstudiante) => {
+  const handleViewDetalle = async (f: ProspectoDetalle) => {
     setSelectedFicha(f)
-    const token = localStorage.getItem("token")
-    try {
-      const res = await fetch(
-        `${API_URL}/documentos/prospecto/${f.id}`,
-        {
-          headers: {
-            Authorization: token ? `Bearer ${token}` : "",
-            Accept: "application/json",
-          },
-        }
-      )
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const docs = await res.json()
-      setSelectedFicha({ ...f, documentos: docs })
-      setActiveTab("documentos")
-      setDetalleModalOpen(true)
-    } catch (err) {
-      console.error("Error cargando documentos:", err)
-      Swal.fire("Error", "No se pudieron cargar los documentos.", "error")
-    }
+    setActiveTab('documentos')
+    setDetalleModalOpen(true)
   }
 
   const handleApprove = async (id: number) => {
@@ -134,7 +98,7 @@ export function GestionFichas() {
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       setFichas(prev =>
-        prev.map(f => (f.id === id ? { ...f, estado: "aprobada" } : f))
+        prev.map(f => (f.id === id ? { ...f, status: "aprobada" } : f))
       )
       incrementarRevisadas()
       await Swal.fire({
@@ -177,12 +141,12 @@ export function GestionFichas() {
   const filteredFichas = fichas.filter(f => {
     const term = searchTerm.toLowerCase()
     return (
-      (f.nombre.toLowerCase().includes(term) ||
-        f.programa.toLowerCase().includes(term) ||
+      (f.nombre_completo.toLowerCase().includes(term) ||
+        f.programas[0]?.programa?.nombre.toLowerCase().includes(term) ||
         f.id.toString().includes(term)) &&
-      (filtroEstado === "todos" || f.estado === filtroEstado) &&
-      (filtroPrioridad === "todas" || f.prioridad === filtroPrioridad) &&
-      (filtroPeriodo === "todos")
+      (filtroEstado === 'todos' || f.status === filtroEstado) &&
+      filtroPrioridad === 'todas' &&
+      filtroPeriodo === 'todos'
     )
   })
 
@@ -295,12 +259,12 @@ export function GestionFichas() {
               {filteredFichas.map(f => (
                 <TableRow key={f.id}>
                   <TableCell>{f.id}</TableCell>
-                  <TableCell>{f.nombre}</TableCell>
-                  <TableCell>{f.programa}</TableCell>
+                  <TableCell>{f.nombre_completo}</TableCell>
+                  <TableCell>{f.programas[0]?.programa?.nombre}</TableCell>
                   <TableCell>{f.fecha}</TableCell>
-                  <TableCell>{getBadgeForEstado(f.estado)}</TableCell>
-                  <TableCell>{getBadgeForPrioridad(f.prioridad)}</TableCell>
-                  <TableCell>{f.ultimaActualizacion}</TableCell>
+                  <TableCell>{getBadgeForEstado(f.status)}</TableCell>
+                  <TableCell>{getBadgeForPrioridad('media')}</TableCell>
+                  <TableCell>{f.fecha}</TableCell>
                   <TableCell>
                     <TooltipProvider>
                       <div className="flex gap-2">
@@ -321,21 +285,21 @@ export function GestionFichas() {
                             <Button
                               variant="ghost"
                               size="icon"
-                              onClick={() => handleApprove(f.id)}
-                              disabled={
-                                f.estado === "aprobada" || processingId === f.id
-                              }
+                                onClick={() => handleApprove(f.id)}
+                                disabled={
+                                  f.status === "aprobada" || processingId === f.id
+                                }
                             >
                               {processingId === f.id ? (
                                 <Loader2 className="h-4 w-4 animate-spin" />
                               ) : (
-                                <CheckCircle
-                                  className={`h-4 w-4 ${
-                                    f.estado === "aprobada"
-                                      ? "text-gray-400"
-                                      : "text-green-500"
-                                  }`}
-                                />
+                                  <CheckCircle
+                                    className={`h-4 w-4 ${
+                                      f.status === "aprobada"
+                                        ? "text-gray-400"
+                                        : "text-green-500"
+                                    }`}
+                                  />
                               )}
                             </Button>
                           </TooltipTrigger>

--- a/components/inscripcion/modal/FichaDetalleModal.tsx
+++ b/components/inscripcion/modal/FichaDetalleModal.tsx
@@ -16,11 +16,11 @@ import { CheckCircle2, XCircle, Send } from "lucide-react"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 
-import { FichaEstudiante } from "../types"
+import { ProspectoDetalle } from "@/types/prospecto"
 import { API_BASE_URL } from "@/utils/apiConfig"
 
 interface Props {
-  ficha: FichaEstudiante
+  ficha: ProspectoDetalle
   isOpen: boolean
   onClose: () => void
   onMarcarRevisada: () => void
@@ -38,89 +38,65 @@ export default function FichaDetalleModal({
   comentarioRevision,
   showSuccessMessage,
 }: Props) {
-  // Estados de datos
-  const [personales, setPersonales] = useState<any>({})
-  const [laborales, setLaborales] = useState<any>({})
-  const [academicos, setAcademicos] = useState<any>({})
-  const [financieros, setFinancieros] = useState<any>({})
-  const [programasInscritos, setProgramasInscritos] = useState<any[]>([])
-  const [documentos, setDocumentos] = useState<any[]>([])
-  const [catalogoProgramas, setCatalogoProgramas] = useState<
-    { id: number; abreviatura: string; nombre_del_programa: string }[]
-  >([])
+  const cuotaMensual = ficha.paymentPlans?.length
+    ? (
+        parseFloat(ficha.monto_inscripcion ?? "0") /
+        ficha.paymentPlans.length
+      ).toFixed(2)
+    : ficha.monto_inscripcion
 
-  // Campos para mostrar
   const camposPersonales: [string, any][] = [
-    ["Nombre completo", personales.nombre],
-    ["País origen", personales.paisOrigen],
-    ["País residencia", personales.paisResidencia],
-    ["Teléfono", personales.telefono],
-    ["DPI", personales.dpi],
-    ["Email personal", personales.emailPersonal],
-    ["Email corporativo", personales.emailCorporativo],
-    ["Fecha Nac.", personales.fechaNacimiento],
-    ["Dirección", personales.direccion],
+    ["Nombre completo", ficha.nombre_completo],
+    ["País origen", ficha.pais_origen],
+    ["País residencia", ficha.pais_residencia],
+    ["Teléfono", ficha.telefono],
+    ["Correo electrónico", ficha.correo_electronico],
+    ["Dirección", ficha.direccion_residencia],
+    ["Departamento", ficha.departamento?.nombre],
+    ["Municipio", ficha.municipio?.nombre],
   ]
 
-  const camposAcademicos: [string, any][] = [
-    ["Modalidad", academicos.modalidad],
-    ["Inicio específico", academicos.fechaInicioEspecifica],
-    ["Taller inducción", academicos.tallerInduccion],
-    ["Taller integración", academicos.tallerIntegracion],
-    ["Institución anterior", academicos.institucionAnterior],
-    ["Año graduación", academicos.añoGraduacion],
-    ["Medio conoció", academicos.medioConocio],
-    ["Cursos aprobados", academicos.cursosAprobados],
-    ["Día de estudio", academicos.diaEstudio],
-  ]
+  const programa = ficha.programas[0]
+  const camposAcademicos: [string, any][] = programa
+    ? [
+        ["Programa", programa.programa.nombre],
+        ["Modalidad", programa.modalidad],
+        ["Inicio específico", programa.fecha_inicio_especifica],
+        ["Año graduación", programa.anio_graduacion],
+        ["Cursos aprobados", programa.cantidad_cursos_aprobados],
+        ["Día de estudio", programa.dia_estudio],
+      ]
+    : []
 
   const camposLaborales: [string, any][] = [
-    ["Empresa", laborales.empresa],
-    ["Puesto", laborales.puesto],
-    ["Teléfono corp.", laborales.telefonoCorporativo],
-    ["Departamento", laborales.departamento],
-    ["Dirección empresa", laborales.direccionEmpresa],
+    ["Empresa", ficha.empresa_donde_labora_actualmente],
+    ["Puesto", ficha.puesto],
+    ["Teléfono corp.", ficha.telefono_corporativo],
+    ["Dirección empresa", ficha.direccion_empresa],
   ]
 
   const camposFinancieros: [string, any][] = [
-    ["Método de pago", financieros.formaPago],
-    ["Convenio ID", financieros.convenioId],
-    ["Inscripción", financieros.inscripcion],
-    ["Cuota mensual", financieros.cuotaMensual],
-    ["Inversión total", financieros.inversionTotal],
+    ["Método de pago", ficha.metodo_pago],
+    ["Inscripción", ficha.monto_inscripcion],
+    ["Cuota mensual", cuotaMensual],
+    ["Convenio", ficha.convenio?.nombre],
   ]
+
+  const programasInscritos = ficha.courses ?? []
+  const documentos = (ficha.documentos ?? []).map(d => ({
+    id: d.id,
+    nombre: d.tipo_documento,
+    url: `${API_BASE_URL}/storage/${d.ruta_archivo}`,
+  }))
 
   // Estados de UI
   const [isRevisada, setIsRevisada] = useState(false)
   const [correctionMode, setCorrectionMode] = useState(false)
 
-  // Carga inicial
   useEffect(() => {
-    if (!isOpen) return
-    ;(async () => {
-      try {
-        const token = localStorage.getItem("token") ?? ""
-        const resFicha = await fetch(
-          `${API_BASE_URL}/api/fichas/${ficha.id}`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        )
-        const json = await resFicha.json()
-        setPersonales(json.personales)
-        setLaborales(json.laborales)
-        setAcademicos(json.academicos)
-        setFinancieros(json.financieros)
-        setProgramasInscritos(json.programas ?? [])
-        setDocumentos(json.documentos ?? [])
-
-        const resProg = await fetch(`${API_BASE_URL}/api/programas`)
-        setCatalogoProgramas(await resProg.json())
-
-        // Leer estado 'revisada' de localStorage
-        setIsRevisada(localStorage.getItem(`ficha-${ficha.id}-revisada`) === "true")
-      } catch (err) {
-        console.error("Error al cargar detalle de ficha:", err)
-      }
-    })()
+    if (isOpen) {
+      setIsRevisada(localStorage.getItem(`ficha-${ficha.id}-revisada`) === 'true')
+    }
   }, [isOpen, ficha.id])
 
   // Marcar como revisada
@@ -138,7 +114,7 @@ export default function FichaDetalleModal({
         <DialogHeader>
           <DialogTitle>Ficha #{ficha.id}</DialogTitle>
           <DialogDescription>
-            {personales.nombre || ficha.nombre}
+            {ficha.nombre_completo}
           </DialogDescription>
         </DialogHeader>
 
@@ -209,27 +185,13 @@ export default function FichaDetalleModal({
               {programasInscritos.length === 0 ? (
                 <p>Sin programas inscritos.</p>
               ) : (
-                programasInscritos.map((p) => {
-                  const meta = catalogoProgramas.find((c) => c.id === p.programa_id)
-                  return (
-                    <Card key={p.id} className="p-2 border rounded">
-                      <CardContent className="space-y-1">
-                        <p>
-                          <strong>
-                            {meta?.abreviatura} – {meta?.nombre_del_programa}
-                          </strong>
-                        </p>
-                        <p>
-                          <strong>Inicio:</strong> {p.fecha_inicio} |{" "}
-                          <strong>Fin:</strong> {p.fecha_fin}
-                        </p>
-                        <p>
-                          <strong>Duración:</strong> {p.duracion_meses} meses
-                        </p>
-                      </CardContent>
-                    </Card>
-                  )
-                })
+                programasInscritos.map(p => (
+                  <Card key={p.id} className="p-2 border rounded">
+                    <CardContent className="space-y-1">
+                      <p>{p.fullname}</p>
+                    </CardContent>
+                  </Card>
+                ))
               )}
             </TabsContent>
 

--- a/services/prospectoService.ts
+++ b/services/prospectoService.ts
@@ -1,5 +1,9 @@
 import api from './api'
-import type { ProspectoConProgramas, Prospecto } from '@/types/prospecto'
+import type {
+  ProspectoConProgramas,
+  Prospecto,
+  ProspectoDetalle,
+} from '@/types/prospecto'
 
 /** Lista todos los prospectos (sin programas) */
 export async function fetchProspectos(): Promise<Prospecto[]> {
@@ -14,4 +18,15 @@ export async function fetchProspectoWithPrograms(
 ): Promise<ProspectoConProgramas> {
   const res = await api.get<{ data: ProspectoConProgramas }>(`/prospectos/${id}`)
   return res.data.data
+}
+
+/** Obtiene prospectos con toda su información relacionada */
+export async function getProspectos(
+  status?: string
+): Promise<ProspectoDetalle[]> {
+  const res = await api.get('/prospectos', {
+    params: status ? { status } : undefined,
+  })
+  const data = Array.isArray(res.data) ? res.data : res.data.data
+  return data as ProspectoDetalle[]
 }

--- a/types/prospecto.ts
+++ b/types/prospecto.ts
@@ -21,3 +21,62 @@ export interface ProspectoConProgramas extends Prospecto {
   programas: EstudiantePrograma[]
   courses: any[] // deja courses si ya lo manejas
 }
+
+export interface Documento {
+  id: number
+  tipo_documento: string
+  ruta_archivo: string
+  estado: string
+}
+
+export interface Convenio {
+  id: number
+  nombre: string
+  descuento: number
+}
+
+export interface Course {
+  id: number
+  fullname: string
+}
+
+export interface ProgramaInscrito {
+  id: number
+  modalidad: string
+  fecha_inicio_especifica: string | null
+  fecha_taller_reduccion: string | null
+  fecha_taller_integracion: string | null
+  anio_graduacion: number | null
+  cantidad_cursos_aprobados: number | null
+  dia_estudio: string | null
+  programa: Programa
+}
+
+/** Prospecto con toda la información relacionada */
+export interface ProspectoDetalle extends Prospecto {
+  fecha?: string
+  telefono?: string
+  correo_electronico?: string
+  genero?: string
+  pais_origen?: string
+  pais_residencia?: string
+  departamento?: { id: number; nombre: string } | null
+  municipio?: { id: number; nombre: string } | null
+  direccion_residencia?: string
+  programas: ProgramaInscrito[]
+  courses: Course[]
+  empresa_donde_labora_actualmente?: string
+  puesto?: string
+  telefono_corporativo?: string | null
+  direccion_empresa?: string
+  metodo_pago?: string
+  monto_inscripcion?: string
+  convenio?: Convenio | null
+  invoices: any[]
+  payments: any[]
+  paymentPlans: any[]
+  collectionLogs: any[]
+  reconciliationRecords: any[]
+  documentos: Documento[]
+  creator?: { id: number; name: string } | null
+}


### PR DESCRIPTION
## Summary
- add comprehensive ProspectoDetalle types
- create `getProspectos` service to retrieve full prospect data
- update revision UI to display fetched data and documents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt; no lint executed)*

------
https://chatgpt.com/codex/tasks/task_e_689441126df48328a04a05dd94f1f6f4