### PR TITLE
feat: allow resubmitting rejected documents

### DIFF
--- a/app/inscripcion/documentos-rechazados/page.tsx
+++ b/app/inscripcion/documentos-rechazados/page.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/use-toast"
+import api from "@/services/api"
+
+interface ProspectDocument {
+  id: number
+  tipo_documento: string
+  estado: string
+  updated_at: string
+}
+
+export default function RejectedDocumentsPage() {
+  const [documents, setDocuments] = useState<ProspectDocument[]>([])
+  const [selected, setSelected] = useState<ProspectDocument | null>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+  const { toast } = useToast()
+
+  const fetchDocuments = async () => {
+    try {
+      const res = await api.get("/documentos")
+      const rejected = res.data.filter((doc: ProspectDocument) => doc.estado === "rechazado")
+      setDocuments(rejected)
+    } catch (error) {
+      console.error(error)
+      toast({ title: "Error", description: "No se pudieron cargar los documentos" })
+    }
+  }
+
+  useEffect(() => {
+    fetchDocuments()
+  }, [])
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0])
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!selected || !file) return
+    const formData = new FormData()
+    formData.append("file", file)
+    formData.append("estado", "pendiente")
+    try {
+      setLoading(true)
+      await api.put(`/documentos/${selected.id}`, formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      })
+      toast({ title: "Documento reenviado" })
+      await fetchDocuments()
+      setSelected(null)
+      setFile(null)
+    } catch (error) {
+      console.error(error)
+      toast({ title: "Error", description: "No se pudo reenviar el documento" })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Reenvío de Documentos Rechazados</h1>
+      {documents.length === 0 ? (
+        <p className="text-gray-500">No hay documentos rechazados.</p>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {documents.map((doc) => (
+            <Card key={doc.id}>
+              <CardHeader>
+                <CardTitle className="flex justify-between items-center">
+                  {doc.tipo_documento}
+                  <span className="text-sm font-normal capitalize text-red-600">{doc.estado}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-gray-600">Última actualización: {new Date(doc.updated_at).toLocaleDateString()}</p>
+              </CardContent>
+              <CardFooter>
+                <Button onClick={() => setSelected(doc)}>Subir corrección</Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={!!selected} onOpenChange={() => { setSelected(null); setFile(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reenviar {selected?.tipo_documento}</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <Input type="file" accept=".pdf,.jpg,.jpeg,.png" onChange={handleFileChange} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setSelected(null); setFile(null); }} disabled={loading}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSubmit} disabled={!file || loading}>
+              {loading ? "Enviando..." : "Enviar corrección"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+

--- a/components/firma/student-details.tsx
+++ b/components/firma/student-details.tsx
@@ -5,6 +5,8 @@ import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +24,7 @@ import { API_BASE_URL } from '@/utils/apiConfig'
 interface Student {
   id: string
   name: string
+  email: string
 }
 interface ProgramaItem {
   id: number
@@ -42,6 +45,7 @@ interface User {
   first_name: string
   last_name: string
   username: string
+  email: string
 }
 
 export function StudentDetails() {
@@ -66,6 +70,14 @@ export function StudentDetails() {
   // Alias al primer programa (si existe)
   const programa = programas[0]
 
+  // Fecha formateada una vez para coincidir con PDF
+  const formattedDate = new Date().toLocaleDateString("es-GT", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+
   // 1) Traer prospecto
   useEffect(() => {
     if (!studentId) return
@@ -81,6 +93,11 @@ export function StudentDetails() {
           setStudent({
             id: String(json.data.id),
             name: json.data.nombre_completo,
+            email:
+              json.data.correo_electronico ||
+              json.data.correo ||
+              json.data.email ||
+              "",
           })
         } catch (err) {
           console.error(err)
@@ -119,6 +136,9 @@ export function StudentDetails() {
         const user: User = await res.json()
         console.log("Usuario recibido:", user)
         setCurrentUser(user)
+        setStudent((prev) =>
+          prev ? { ...prev, email: prev.email || user.email } : prev
+        )
       } catch (err) {
         console.error(err)
       }
@@ -193,6 +213,10 @@ export function StudentDetails() {
       alert("Por favor, firme el contrato antes de enviarlo.")
       return
     }
+    if (!currentUser?.email) {
+      alert("No se pudo obtener el correo del usuario.")
+      return
+    }
     setShowConfirmDialog(true)
   }
   const confirmSendContract = async () => {
@@ -210,7 +234,18 @@ export function StudentDetails() {
             "Content-Type": "application/json",
             Accept: "application/json",
           },
-          body: JSON.stringify({ signature }),
+          body: JSON.stringify({
+            signature,
+            email: currentUser?.email || student?.email,
+            prospecto: student?.name,
+            programa: programa?.programa.nombre_del_programa,
+            matricula: programa?.inscripcion,
+            mensualidad: programa?.cuota_mensual,
+            asesor: currentUser
+              ? `${currentUser.first_name} ${currentUser.last_name}`
+              : "",
+            fecha: formattedDate,
+          }),
         }
       )
       if (!res.ok) {
@@ -258,6 +293,10 @@ export function StudentDetails() {
         ID Estudiante: {student.id}
       </p>
       <p className="text-lg font-semibold mb-4">{student.name}</p>
+      <div className="mb-4 max-w-md">
+        <Label htmlFor="email">Correo electrónico</Label>
+        <Input id="email" value={currentUser?.email || student.email} readOnly />
+      </div>
 
       <Card>
         <CardHeader className="flex justify-between items-center">
@@ -283,16 +322,12 @@ export function StudentDetails() {
             </p>
             <p>(Por favor firme ambas páginas en donde corresponde)</p>
             <p>
-              En la ciudad de Guatemala, el día:{" "}
-              {new Date().toLocaleDateString("es-GT", {
-                weekday: "long",
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
+              En la ciudad de Guatemala, el día: {formattedDate}
             </p>
             <p>
-              Yo: <strong>{student.name}</strong> &nbsp;&nbsp;Firma: __________________________
+              Yo: <strong>{student.name}</strong>{" "}
+              {student.email && <span>({student.email})</span>} &nbsp;&nbsp;Firma:
+              __________________________
             </p>
             <p>
               Me comprometo a mantener de manera estrictamente confidencial los

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -306,6 +306,17 @@ export default function Sidebar({ open, className }: SidebarProps) {
                   <span>Validación de Documentos</span>
                 </Link>
 
+                <Link
+                  href="/inscripcion/documentos-rechazados"
+                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/inscripcion/documentos-rechazados"
+                    ? "bg-asm-medium-gold text-white"
+                    : "text-asm-light-gold hover:bg-asm-medium-gold/20"
+                    } transition-colors duration-200`}
+                >
+                  <RefreshCw size={16} className="mr-2" />
+                  <span>Docs Rechazados</span>
+                </Link>
+
                 <div className="mt-2 mb-1 px-4 py-1 text-xs font-medium text-asm-light-gold/70">
                   Administración
                 </div>
@@ -411,16 +422,14 @@ export default function Sidebar({ open, className }: SidebarProps) {
                 </Link>
                 {/* <Link
                   href="/academico/estado-sistema"
-                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/estado-sistema" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
-                    } transition-colors duration-200`}
+                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/estado-sistema" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"} transition-colors duration-200`}
                 >
                   <Activity size={16} className="mr-2" />
                   <span>Estatus General</span>
                 </Link> */}
                 <Link
                   href="/academico/ranking"
-                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/ranking" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"
-                    } transition-colors duration-200`}
+                  className={`flex items-center px-4 py-1.5 rounded-md ${pathname === "/academico/ranking" ? "bg-asm-medium-gold text-white" : "text-asm-light-gold hover:bg-asm-medium-gold/20"} transition-colors duration-200`}
                 >
                   <BarChart2 size={16} className="mr-2" />
                   <span>Ranking Académico</span>


### PR DESCRIPTION
## Summary
- add page under Inscripción for resubmitting rejected prospect documents
- link new screen from sidebar for quick access
- include prospect email in digital contract preview and send contract details along with signature
- prefill contract with logged-in user email and use shared formatted date when sending
- refresh rejected documents list after resubmitting a correction

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c4f33a988328bb1c28e84651c32a