### PR TITLE
Allow empty appointment descriptions and fix default time

### DIFF
--- a/app/seguimiento/page.tsx
+++ b/app/seguimiento/page.tsx
@@ -61,8 +61,13 @@ export default function SeguimientoPage() {
     const off = date.getTimezoneOffset() * 60000;
     return new Date(date.getTime() - off).toISOString().slice(0, 16);
   };
+  const getDefaultAppointmentDate = () => {
+    const d = new Date();
+    d.setHours(9, 0, 0, 0);
+    return toLocalInputValue(d);
+  };
   const [citas, setCitas] = useState<any[]>([]);
-  const [appointmentDate, setAppointmentDate] = useState<string>(toLocalInputValue(new Date()));
+  const [appointmentDate, setAppointmentDate] = useState<string>(getDefaultAppointmentDate());
   const [appointmentDescription, setAppointmentDescription] = useState<string>("");
 
   // Estado para almacenar actividades
@@ -304,11 +309,11 @@ export default function SeguimientoPage() {
 
   // Manejo para agregar cita
   const handleAddCita = async () => {
-    if (!appointmentDate || !appointmentDescription.trim()) {
+    if (!appointmentDate) {
       Swal.fire({
         icon: "warning",
         title: "Campos incompletos",
-        text: "Completa la fecha y la descripción para la cita.",
+        text: "Selecciona la fecha para la cita.",
       });
       return;
     }
@@ -333,7 +338,7 @@ export default function SeguimientoPage() {
     const formattedDate = date.toISOString();
     const newCita = {
       datecita: formattedDate,
-      descricita: appointmentDescription,
+      descricita: appointmentDescription.trim(),
     };
 
     console.log("Enviando cita:", JSON.stringify(newCita, null, 2));
@@ -344,7 +349,7 @@ export default function SeguimientoPage() {
       console.log("✅ Cita guardada:", response.data);
       setCitas((prev) => [...prev, saved]);
       setAppointmentDescription("");
-      setAppointmentDate(toLocalInputValue(new Date()));
+      setAppointmentDate(getDefaultAppointmentDate());
       Swal.fire({
         icon: "success",
         title: "¡Cita Agendada!",


### PR DESCRIPTION
## Summary
- Allow scheduling follow-up appointments without requiring a description
- Set default appointment time to 9:00 AM using helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'React' must be in scope when using JSX, unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68975ee4255c8328a880b1cb884bf160