### PR TITLE
fix: improve ficha detalle modal data rendering

### DIFF
--- a/components/inscripcion/modal/FichaDetalleModal.tsx
+++ b/components/inscripcion/modal/FichaDetalleModal.tsx
@@ -18,6 +18,8 @@ import { Textarea } from "@/components/ui/textarea"
 
 import { FichaEstudiante } from "../types"
 import { API_BASE_URL } from "@/utils/apiConfig"
+import fetchFicha from "@/services/fichas"
+import { formatDate } from "@/utils/formatDate"
 
 interface Props {
   ficha: FichaEstudiante
@@ -45,9 +47,6 @@ export default function FichaDetalleModal({
   const [financieros, setFinancieros] = useState<any>({})
   const [programasInscritos, setProgramasInscritos] = useState<any[]>([])
   const [documentos, setDocumentos] = useState<any[]>([])
-  const [catalogoProgramas, setCatalogoProgramas] = useState<
-    { id: number; abreviatura: string; nombre_del_programa: string }[]
-  >([])
 
   // Campos para mostrar
   const camposPersonales: [string, any][] = [
@@ -58,15 +57,15 @@ export default function FichaDetalleModal({
     ["DPI", personales.dpi],
     ["Email personal", personales.emailPersonal],
     ["Email corporativo", personales.emailCorporativo],
-    ["Fecha Nac.", personales.fechaNacimiento],
+    ["Fecha Nac.", formatDate(personales.fechaNacimiento)],
     ["Dirección", personales.direccion],
   ]
 
   const camposAcademicos: [string, any][] = [
     ["Modalidad", academicos.modalidad],
-    ["Inicio específico", academicos.fechaInicioEspecifica],
-    ["Taller inducción", academicos.tallerInduccion],
-    ["Taller integración", academicos.tallerIntegracion],
+    ["Inicio específico", formatDate(academicos.fechaInicioEspecifica)],
+    ["Taller inducción", formatDate(academicos.fechaTallerInduccion)],
+    ["Taller integración", formatDate(academicos.fechaTallerIntegracion)],
     ["Institución anterior", academicos.institucionAnterior],
     ["Año graduación", academicos.añoGraduacion],
     ["Medio conoció", academicos.medioConocio],
@@ -84,7 +83,7 @@ export default function FichaDetalleModal({
 
   const camposFinancieros: [string, any][] = [
     ["Método de pago", financieros.formaPago],
-    ["Convenio ID", financieros.convenioId],
+    ["Convenio", financieros.convenioNombre],
     ["Inscripción", financieros.inscripcion],
     ["Cuota mensual", financieros.cuotaMensual],
     ["Inversión total", financieros.inversionTotal],
@@ -99,24 +98,37 @@ export default function FichaDetalleModal({
     if (!isOpen) return
     ;(async () => {
       try {
-        const token = localStorage.getItem("token") ?? ""
-        const resFicha = await fetch(
-          `${API_BASE_URL}/api/fichas/${ficha.id}`,
-          { headers: { Authorization: `Bearer ${token}` } }
+        const data = await fetchFicha(ficha.id)
+        console.log(
+          `[FichaDetalleModal] datos recibidos para prospecto ${ficha.id}:`,
+          data,
         )
-        const json = await resFicha.json()
-        setPersonales(json.personales)
-        setLaborales(json.laborales)
-        setAcademicos(json.academicos)
-        setFinancieros(json.financieros)
-        setProgramasInscritos(json.programas ?? [])
-        setDocumentos(json.documentos ?? [])
-
-        const resProg = await fetch(`${API_BASE_URL}/api/programas`)
-        setCatalogoProgramas(await resProg.json())
+        if (!data.documentos?.length) {
+          console.warn(
+            `[FichaDetalleModal] sin documentos. Verificar GET /api/documentos/prospecto/${ficha.id}`,
+          )
+        }
+        if (data.financieros?.convenioId && !data.financieros?.convenioNombre) {
+          console.warn(
+            `[FichaDetalleModal] convenio ${data.financieros.convenioId} sin nombre. Revisar GET /api/convenios/${data.financieros.convenioId}`,
+          )
+        }
+        if (!data.laborales?.departamento) {
+          console.warn(
+            "[FichaDetalleModal] departamento no resuelto. El backend debe enviar 'departamento_nombre' o usar /api/ubicacion/{paisId}",
+          )
+        }
+        setPersonales(data.personales || {})
+        setLaborales(data.laborales || {})
+        setAcademicos(data.academicos || {})
+        setFinancieros(data.financieros || {})
+        setProgramasInscritos(data.programas || [])
+        setDocumentos(data.documentos || [])
 
         // Leer estado 'revisada' de localStorage
-        setIsRevisada(localStorage.getItem(`ficha-${ficha.id}-revisada`) === "true")
+        setIsRevisada(
+          localStorage.getItem(`ficha-${ficha.id}-revisada`) === "true"
+        )
       } catch (err) {
         console.error("Error al cargar detalle de ficha:", err)
       }
@@ -161,7 +173,7 @@ export default function FichaDetalleModal({
               {camposPersonales.map(([label, val], i) => (
                 <div key={i} className="p-2 border rounded">
                   <Label>{label}</Label>
-                  <p className="mt-1">{val ?? "—"}</p>
+                  <p className="mt-1">{val === null || val === undefined || val === "" ? "—" : val}</p>
                 </div>
               ))}
             </TabsContent>
@@ -172,7 +184,7 @@ export default function FichaDetalleModal({
                 {camposAcademicos.map(([label, val], i) => (
                   <div key={i} className="p-2 border rounded">
                     <Label>{label}</Label>
-                    <p className="mt-1">{val ?? "—"}</p>
+                    <p className="mt-1">{val === null || val === undefined || val === "" ? "—" : val}</p>
                   </div>
                 ))}
               </div>
@@ -186,7 +198,7 @@ export default function FichaDetalleModal({
               {camposLaborales.map(([label, val], i) => (
                 <div key={i} className="p-2 border rounded">
                   <Label>{label}</Label>
-                  <p className="mt-1">{val ?? "—"}</p>
+                  <p className="mt-1">{val === null || val === undefined || val === "" ? "—" : val}</p>
                 </div>
               ))}
             </TabsContent>
@@ -199,7 +211,7 @@ export default function FichaDetalleModal({
               {camposFinancieros.map(([label, val], i) => (
                 <div key={i} className="p-2 border rounded">
                   <Label>{label}</Label>
-                  <p className="mt-1">{val ?? "—"}</p>
+                  <p className="mt-1">{val === null || val === undefined || val === "" ? "—" : val}</p>
                 </div>
               ))}
             </TabsContent>
@@ -209,27 +221,32 @@ export default function FichaDetalleModal({
               {programasInscritos.length === 0 ? (
                 <p>Sin programas inscritos.</p>
               ) : (
-                programasInscritos.map((p) => {
-                  const meta = catalogoProgramas.find((c) => c.id === p.programa_id)
-                  return (
-                    <Card key={p.id} className="p-2 border rounded">
-                      <CardContent className="space-y-1">
-                        <p>
-                          <strong>
-                            {meta?.abreviatura} – {meta?.nombre_del_programa}
-                          </strong>
-                        </p>
-                        <p>
-                          <strong>Inicio:</strong> {p.fecha_inicio} |{" "}
-                          <strong>Fin:</strong> {p.fecha_fin}
-                        </p>
-                        <p>
-                          <strong>Duración:</strong> {p.duracion_meses} meses
-                        </p>
-                      </CardContent>
-                    </Card>
-                  )
-                })
+                programasInscritos.map((p) => (
+                  <Card key={p.id} className="p-2 border rounded">
+                    <CardContent className="space-y-1">
+                      <p>
+                        <strong>
+                          {p.programa?.abreviatura} – {p.programa?.nombre_del_programa}
+                        </strong>
+                      </p>
+                      <p>
+                        <strong>Inicio:</strong> {formatDate(p.fecha_inicio)} | <strong>Fin:</strong> {formatDate(p.fecha_fin)}
+                      </p>
+                      <p>
+                        <strong>Duración:</strong> {p.duracion_meses} meses
+                      </p>
+                      <p>
+                        <strong>Inscripción:</strong> {p.inscripcion ?? "—"}
+                      </p>
+                      <p>
+                        <strong>Cuota mensual:</strong> {p.cuota_mensual ?? "—"}
+                      </p>
+                      <p>
+                        <strong>Inversión total:</strong> {p.inversion_total ?? "—"}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))
               )}
             </TabsContent>
 
@@ -240,18 +257,25 @@ export default function FichaDetalleModal({
               ) : (
                 documentos.map((d) => (
                   <Card key={d.id} className="p-2 border rounded">
-                    <CardContent className="space-y-1">
-                      <p>
-                        <strong>{d.nombre}</strong>
-                      </p>
-                      <a
-                        href={d.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-sm underline"
-                      >
-                        Ver archivo
-                      </a>
+                    <CardContent className="flex items-center justify-between">
+                      <div>
+                        <p>
+                          <strong>{d.nombre}</strong>
+                        </p>
+                        <p className="text-sm capitalize">
+                          {d.estado || (d.url ? "cargado" : "pendiente")}
+                        </p>
+                      </div>
+                      {d.url ? (
+                        <a
+                          href={d.url || `${API_BASE_URL}/api/documentos/${d.id}/file`}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-sm underline"
+                        >
+                          Ver/Descargar
+                        </a>
+                      ) : null}
                     </CardContent>
                   </Card>
                 ))

--- a/components/inscripcion/types.ts
+++ b/components/inscripcion/types.ts
@@ -81,15 +81,19 @@ export interface DatosFinancieros {
   aceptaTerminos: boolean;
   tieneConvenio: boolean;
   convenioId?: number;
+  /** Nombre del convenio asociado, si aplica */
+  convenioNombre?: string;
 }
 
 export interface Documento {
-  id: string;
+  id: string | number;
   nombre: string;
   descripcion: string;
   estado: "pendiente" | "cargado";
   archivos: File[];
   optional?: boolean;
+  /** URL para descarga del documento */
+  url?: string;
 }
 
 /** Ficha de inscripción del estudiante */

--- a/services/fichas.ts
+++ b/services/fichas.ts
@@ -1,0 +1,186 @@
+import api from './api'
+import type {
+  DatosPersonales,
+  DatosLaborales,
+  DatosAcademicos,
+  DatosFinancieros,
+  Documento,
+} from '@/components/inscripcion/types'
+
+export interface FichaDetalle {
+  personales: Partial<DatosPersonales>
+  laborales: Partial<DatosLaborales>
+  academicos: Partial<DatosAcademicos>
+  financieros: Partial<DatosFinancieros>
+  programas: any[]
+  documentos: Documento[]
+}
+
+async function buildFromProspecto(prospecto: any): Promise<FichaDetalle> {
+  let convenioNombre: string | undefined
+  if (prospecto.convenio?.nombre) {
+    convenioNombre = prospecto.convenio.nombre
+  } else if (prospecto.convenio_pago_id) {
+    try {
+      const { data } = await api.get(`/convenios/${prospecto.convenio_pago_id}`)
+      convenioNombre = data?.nombre
+    } catch {
+      // ignore
+    }
+  }
+
+  // Documentos
+  let documentos: Documento[] = []
+  try {
+    const { data } = await api.get(`/documentos/prospecto/${prospecto.id}`)
+    documentos = Array.isArray(data)
+      ? data.map((d: any) => ({
+          ...d,
+          estado: d.url ? 'cargado' : 'pendiente',
+        }))
+      : []
+  } catch {
+    documentos = []
+  }
+
+  // Departamento nombre
+  let departamentoNombre = prospecto.departamento_nombre
+  const depId = Number(prospecto.departamento)
+  if (!departamentoNombre && !isNaN(depId)) {
+    try {
+      const pais =
+        prospecto.pais_residencia_id ||
+        prospecto.pais_id ||
+        prospecto.pais_residencia ||
+        ''
+      const { data } = await api.get(`/ubicacion/${pais}`)
+      const dep = data?.departamentos?.find((d: any) => d.id === depId)
+      departamentoNombre = dep?.nombre
+    } catch {
+      // ignore
+    }
+  }
+
+  const programa0 = prospecto.programas?.[0]
+  const inscripcion =
+    programa0?.inscripcion ??
+    (prospecto.monto_inscripcion > 0 ? prospecto.monto_inscripcion : undefined)
+  const cuotaMensual = programa0?.cuota_mensual
+  const inversionTotal = programa0?.inversion_total
+
+  return {
+    personales: {
+      nombre: prospecto.nombre_completo,
+      paisOrigen: prospecto.pais_origen,
+      paisResidencia: prospecto.pais_residencia,
+      telefono: prospecto.telefono,
+      dpi: prospecto.numero_identificacion,
+      emailPersonal: prospecto.correo_electronico,
+      emailCorporativo: prospecto.correo_corporativo,
+      fechaNacimiento: prospecto.fecha_nacimiento,
+      direccion: prospecto.direccion_residencia,
+    },
+    laborales: {
+      empresa: prospecto.empresa_donde_labora_actualmente,
+      puesto: prospecto.puesto,
+      telefonoCorporativo: prospecto.telefono_corporativo,
+      departamento: departamentoNombre,
+      direccionEmpresa: prospecto.direccion_empresa,
+      sectorEmpresa: prospecto.sector_empresa,
+    },
+    academicos: {
+      modalidad: prospecto.modalidad,
+      fechaInicioEspecifica: prospecto.fecha_inicio_especifica,
+      fechaTallerInduccion: prospecto.fecha_taller_reduccion,
+      fechaTallerIntegracion: prospecto.fecha_taller_integracion,
+      institucionAnterior: prospecto.institucion_titulo,
+      añoGraduacion: prospecto.anio_graduacion,
+      medioConocio: prospecto.medio_conocimiento_institucion,
+      cursosAprobados: prospecto.cantidad_cursos_aprobados,
+      diaEstudio: prospecto.dia_estudio
+        ? String(prospecto.dia_estudio).toLowerCase()
+        : undefined,
+    },
+    financieros: {
+      formaPago: prospecto.metodo_pago,
+      convenioId: prospecto.convenio_pago_id,
+      convenioNombre,
+      inscripcion,
+      cuotaMensual,
+      inversionTotal,
+    },
+    programas: prospecto.programas || [],
+    documentos,
+  }
+}
+
+export async function fetchFicha(id: number): Promise<FichaDetalle> {
+  try {
+    const { data } = await api.get(`/fichas/${id}`)
+
+    const documentos = Array.isArray(data.documentos)
+      ? data.documentos.map((d: any) => ({
+          ...d,
+          estado: d.url ? 'cargado' : 'pendiente',
+        }))
+      : []
+
+    const academicos = {
+      modalidad: data.academicos?.modalidad,
+      fechaInicioEspecifica: data.academicos?.fechaInicioEspecifica,
+      fechaTallerInduccion:
+        data.academicos?.fechaTallerInduccion ??
+        data.academicos?.tallerInduccion ??
+        data.academicos?.fechaTallerReduccion ??
+        data.academicos?.tallerReduccion,
+      fechaTallerIntegracion:
+        data.academicos?.fechaTallerIntegracion ??
+        data.academicos?.tallerIntegracion,
+      institucionAnterior: data.academicos?.institucionAnterior,
+      añoGraduacion: data.academicos?.añoGraduacion,
+      medioConocio: data.academicos?.medioConocio,
+      cursosAprobados: data.academicos?.cursosAprobados,
+      diaEstudio: data.academicos?.diaEstudio
+        ? String(data.academicos.diaEstudio).toLowerCase()
+        : undefined,
+    }
+
+    const laborales = {
+      ...data.laborales,
+      departamento:
+        data.laborales?.departamentoNombre || data.laborales?.departamento,
+    }
+
+    const financieros = {
+      ...data.financieros,
+      convenioNombre:
+        data.financieros?.convenioNombre || data.financieros?.convenio?.nombre,
+    }
+
+    const programas = data.programas || []
+
+    const needsProspecto =
+      !programas[0]?.programa ||
+      (!financieros.convenioNombre && financieros.convenioId) ||
+      (!laborales.departamento || !isNaN(Number(laborales.departamento)))
+
+    if (!needsProspecto) {
+      return {
+        personales: data.personales || {},
+        laborales,
+        academicos,
+        financieros,
+        programas,
+        documentos,
+      }
+    }
+  } catch {
+    // ignore y hacer fallback
+  }
+
+  const { data: prospecto } = await api.get(`/prospectos/${id}`)
+  return buildFromProspecto(prospecto)
+}
+
+export default fetchFicha
+

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,0 +1,13 @@
+/**
+ * Formats an ISO date string into dd/MM/yyyy without timezone shifts.
+ * Returns "—" when the value is falsy or cannot be parsed.
+ */
+export function formatDate(value?: string): string {
+  if (!value) return '—'
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})/.exec(value)
+  if (!match) return '—'
+  const [, year, month, day] = match
+  return `${day}/${month}/${year}`
+}
+
+export default formatDate


### PR DESCRIPTION
## Summary
- normalize academic field names in `FichaDetalleModal` to display workshop dates
- enrich `fetchFicha` service to unify `/fichas` responses and fetch program details when missing
- normalize date formatting and department lookup for ficha details

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 'React' must be in scope when using JSX)


------
https://chatgpt.com/codex/tasks/task_e_68990b148cc08328910038ca6abd6042