### PR TITLE
Implement front-end permission gating across modules

### DIFF
--- a/app/academico/layout.tsx
+++ b/app/academico/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function AcademicoLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/academico" action="view">{children}</Permission>;
+}
+

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/admin" action="view">{children}</Permission>;
+}
+

--- a/app/captura/layout.tsx
+++ b/app/captura/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function CapturaLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/captura" action="view">{children}</Permission>;
+}
+

--- a/app/docente/layout.tsx
+++ b/app/docente/layout.tsx
@@ -1,13 +1,14 @@
-import type { Metadata } from "next"
-import type { ReactNode } from "react"
+"use client";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
 
 export const metadata: Metadata = {
   title: "Portal Docente | Blue Atlas",
   description: "Portal centralizado para docentes",
-}
+};
 
 export default function DocenteLayout({ children }: { children: ReactNode }) {
-  // Simplemente pasamos los children sin agregar ninguna estructura adicional
-  return <>{children}</>
+  return <Permission viewPath="/docente" action="view">{children}</Permission>;
 }
 

--- a/app/estudiantes/layout.tsx
+++ b/app/estudiantes/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function EstudiantesLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/estudiantes" action="view">{children}</Permission>;
+}
+

--- a/app/finanzas/layout.tsx
+++ b/app/finanzas/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function FinanzasLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/finanzas" action="view">{children}</Permission>;
+}
+

--- a/app/gestion/layout.tsx
+++ b/app/gestion/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function GestionLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/gestion" action="view">{children}</Permission>;
+}
+

--- a/app/importar-leads/layout.tsx
+++ b/app/importar-leads/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function ImportarLeadsLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/importar-leads" action="view">{children}</Permission>;
+}
+

--- a/app/inscripcion/layout.tsx
+++ b/app/inscripcion/layout.tsx
@@ -1,27 +1,29 @@
-"use client"
+"use client";
 
-import type React from "react"
-
-import { ArrowLeft } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import Link from "next/link"
+import type React from "react";
+import Permission from "@/components/Permission";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 export default function InscripcionLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div>
-      <div className="container mx-auto max-w-6xl p-6">
-        <div className="mb-6 flex justify-between items-center">
-          <h1 className="text-3xl font-bold text-blue-900">Ficha de Inscripción</h1>
-          <Link href="/">
-            <Button variant="outline" size="sm">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Volver al inicio
-            </Button>
-          </Link>
+    <Permission viewPath="/inscripcion" action="view">
+      <div>
+        <div className="container mx-auto max-w-6xl p-6">
+          <div className="mb-6 flex justify-between items-center">
+            <h1 className="text-3xl font-bold text-blue-900">Ficha de Inscripción</h1>
+            <Link href="/">
+              <Button variant="outline" size="sm">
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Volver al inicio
+              </Button>
+            </Link>
+          </div>
+          {children}
         </div>
-        {children}
       </div>
-    </div>
-  )
+    </Permission>
+  );
 }
 

--- a/app/interacciones-leads/layout.tsx
+++ b/app/interacciones-leads/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function InteraccionesLeadsLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/interacciones-leads" action="view">{children}</Permission>;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,21 @@
-import type React from "react"
-import type { Metadata } from "next"
-import "./globals.css"
-import MainLayout from "@/components/layout/main-layout"
-import { ThemeProvider } from "@/components/theme-provider"
-import { Suspense } from "react"
-import { AuthProvider } from "@/contexts/AuthContext"
-
+import type React from "react";
+import type { Metadata } from "next";
+import "./globals.css";
+import MainLayout from "@/components/layout/main-layout";
+import { ThemeProvider } from "@/components/theme-provider";
+import { Suspense } from "react";
+import { AuthProvider } from "@/contexts/AuthContext";
+import { PermissionsProvider } from "@/contexts/PermissionsContext";
 
 export const metadata: Metadata = {
   title: "American School of Management",
   description: "Sistema de Gestión Académica",
-}
+};
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode
+  children: React.ReactNode;
 }>) {
   return (
     <html lang="es" suppressHydrationWarning>
@@ -23,11 +23,14 @@ export default function RootLayout({
         <Suspense fallback={<div>Cargando...</div>}>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
             <AuthProvider>
-              <MainLayout>{children}</MainLayout>
+              <PermissionsProvider>
+                <MainLayout>{children}</MainLayout>
+              </PermissionsProvider>
             </AuthProvider>
           </ThemeProvider>
         </Suspense>
       </body>
     </html>
-  )
+  );
 }
+

--- a/app/leads-asignados/layout.tsx
+++ b/app/leads-asignados/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function LeadsAsignadosLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/leads-asignados" action="view">{children}</Permission>;
+}
+

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react"
 import { api } from "@/services/api"
 import { useAuth } from "@/contexts/AuthContext"
+import { usePermissions } from "@/hooks/usePermissions"
 import { useRouter } from "next/navigation"
 import { Eye, EyeOff, LogIn } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -13,6 +14,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 export default function LoginPage() {
   const router = useRouter()
   const { setToken, setAllowedViews } = useAuth()
+  const { setPermissions } = usePermissions()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
@@ -36,11 +38,12 @@ export default function LoginPage() {
 
 
       // Extrae token, user y allowedViews de la respuesta
-      const { id, token, user, allowedViews } = response.data
+      const { id, token, user, allowedViews, permissions } = response.data
 
       // Almacena el token y demás datos en localStorage mediante el contexto
       setToken(token)
       setAllowedViews(allowedViews || [])
+      setPermissions(permissions || [])
       localStorage.setItem("userId", id)
       localStorage.setItem("user", JSON.stringify(user))
 

--- a/app/seguimiento/layout.tsx
+++ b/app/seguimiento/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function SeguimientoLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/seguimiento" action="view">{children}</Permission>;
+}
+

--- a/app/seguridad/layout.tsx
+++ b/app/seguridad/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function SeguridadLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/seguridad" action="view">{children}</Permission>;
+}
+

--- a/app/tareas-asesor/layout.tsx
+++ b/app/tareas-asesor/layout.tsx
@@ -1,0 +1,8 @@
+"use client";
+import type { ReactNode } from "react";
+import Permission from "@/components/Permission";
+
+export default function TareasAsesorLayout({ children }: { children: ReactNode }) {
+  return <Permission viewPath="/tareas-asesor" action="view">{children}</Permission>;
+}
+

--- a/components/Permission.tsx
+++ b/components/Permission.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { usePermissions } from "@/hooks/usePermissions";
+
+interface Props {
+  viewPath: string;
+  action: string;
+  children: ReactNode;
+}
+
+export default function Permission({ viewPath, action, children }: Props) {
+  const { can } = usePermissions();
+  const router = useRouter();
+  const allowed = can(viewPath, action);
+
+  useEffect(() => {
+    if (!allowed) {
+      router.replace("/403");
+    }
+  }, [allowed, router]);
+
+  if (!allowed) return null;
+  return <>{children}</>;
+}
+

--- a/contexts/PermissionsContext.tsx
+++ b/contexts/PermissionsContext.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export interface PermissionEntry {
+  view_path: string;
+  permissions: Record<string, boolean>;
+}
+
+interface PermissionsContextType {
+  permissions: PermissionEntry[];
+  setPermissions: (p: PermissionEntry[]) => void;
+  can: (viewPath: string, action: string) => boolean;
+}
+
+const PermissionsContext = createContext<PermissionsContextType>({
+  permissions: [],
+  setPermissions: () => {},
+  can: () => false,
+});
+
+export const PermissionsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [permissions, setPermissionsState] = useState<PermissionEntry[]>([]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("permissions");
+      if (stored) {
+        try {
+          setPermissionsState(JSON.parse(stored));
+        } catch (e) {
+          console.error("Error parseando permisos", e);
+        }
+      }
+    }
+  }, []);
+
+  const setPermissions = (p: PermissionEntry[]) => {
+    setPermissionsState(p);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("permissions", JSON.stringify(p));
+    }
+  };
+
+  const can = (viewPath: string, action: string) => {
+    const mod = permissions.find((m) => m.view_path === viewPath);
+    return mod?.permissions?.[action] === true;
+  };
+
+  return (
+    <PermissionsContext.Provider value={{ permissions, setPermissions, can }}>
+      {children}
+    </PermissionsContext.Provider>
+  );
+};
+
+export function usePermissions() {
+  return useContext(PermissionsContext);
+}
+
+export default PermissionsContext;
+

--- a/hooks/obtener_permisos.tsx
+++ b/hooks/obtener_permisos.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-function useUserPermissions() {
+export function useUserPermissions() {
   const [permissions, setPermissions] = useState<any[]>([]);
 
   useEffect(() => {
@@ -16,10 +16,10 @@ function useUserPermissions() {
 
   return permissions;
 }
-function hasPermission(permissions: any[], requiredPath: string) {
-    return permissions.some(
-      (permiso) => permiso.permission && permiso.permission.view_path === requiredPath
-    );
-  }
 
-  
+export function hasPermission(permissions: any[], requiredPath: string) {
+  return permissions.some(
+    (permiso) => permiso.permission && permiso.permission.view_path === requiredPath
+  );
+}
+

--- a/hooks/usePermissions.ts
+++ b/hooks/usePermissions.ts
@@ -1,0 +1,8 @@
+"use client";
+import { useContext } from "react";
+import PermissionsContext from "@/contexts/PermissionsContext";
+
+export function usePermissions() {
+  return useContext(PermissionsContext);
+}
+


### PR DESCRIPTION
## Summary
- add global PermissionsContext with `can` helper for view/action checks
- provide Permission component and wrap layouts for modules like finanzas, docencia, seguridad, inscripción, etc.
- persist and load permissions at login and root layout
- restore legacy `useUserPermissions` and `hasPermission` helpers for compatibility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: React must be in scope for JSX and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689b6246833c8328a4fe12d407d6b013