### PR TITLE
feat: add frontend permission layer

### DIFF
--- a/app/finanzas/conciliacion/conciliacion-client.tsx
+++ b/app/finanzas/conciliacion/conciliacion-client.tsx
@@ -26,6 +26,8 @@ import {
   XCircle,
 } from "lucide-react"
 import Link from "next/link"
+import IfCan from "@/permissions/IfCan"
+import { ROUTES } from "@/constants/routes"
 
 export default function ConciliacionClient() {
   const [activeTab, setActiveTab] = useState("pendientes")
@@ -220,10 +222,12 @@ export default function ConciliacionClient() {
                 <CardDescription>Gestione los recibos de pago pendientes de conciliación.</CardDescription>
               </div>
               <div className="flex gap-2">
-                <Button variant="outline" size="sm" onClick={handleExportResults}>
-                  <Download className="mr-2 h-4 w-4" />
-                  Exportar
-                </Button>
+                <IfCan routePath={ROUTES.conciliacion} action="export">
+                  <Button variant="outline" size="sm" onClick={handleExportResults}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Exportar
+                  </Button>
+                </IfCan>
               </div>
             </CardHeader>
             <CardContent>
@@ -314,10 +318,12 @@ export default function ConciliacionClient() {
                 <CardTitle>Recibos Conciliados</CardTitle>
                 <CardDescription>Historial de recibos de pago conciliados.</CardDescription>
               </div>
-              <Button variant="outline" size="sm" onClick={handleExportResults}>
-                <Download className="mr-2 h-4 w-4" />
-                Exportar
-              </Button>
+                <IfCan routePath={ROUTES.conciliacion} action="export">
+                  <Button variant="outline" size="sm" onClick={handleExportResults}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Exportar
+                  </Button>
+                </IfCan>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between mb-4">
@@ -386,10 +392,12 @@ export default function ConciliacionClient() {
                 <CardTitle>Recibos Rechazados</CardTitle>
                 <CardDescription>Historial de recibos de pago rechazados.</CardDescription>
               </div>
-              <Button variant="outline" size="sm" onClick={handleExportResults}>
-                <Download className="mr-2 h-4 w-4" />
-                Exportar
-              </Button>
+                <IfCan routePath={ROUTES.conciliacion} action="export">
+                  <Button variant="outline" size="sm" onClick={handleExportResults}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Exportar
+                  </Button>
+                </IfCan>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between mb-4">
@@ -484,11 +492,13 @@ export default function ConciliacionClient() {
                         </Button>
                       </div>
                     </div>
-                    {selectedFile && (
-                      <Button variant="outline" onClick={() => setSelectedFile(null)}>
-                        Eliminar
-                      </Button>
-                    )}
+                      {selectedFile && (
+                        <IfCan routePath={ROUTES.conciliacion} action="delete">
+                          <Button variant="outline" onClick={() => setSelectedFile(null)}>
+                            Eliminar
+                          </Button>
+                        </IfCan>
+                      )}
                   </div>
                 </div>
 
@@ -506,10 +516,12 @@ export default function ConciliacionClient() {
                       </>
                     )}
                   </Button>
-                  <Button onClick={handleImport} disabled={!selectedFile}>
-                    <Upload className="mr-2 h-4 w-4" />
-                    Importar Recibos
-                  </Button>
+                    <IfCan routePath={ROUTES.conciliacion} action="create">
+                      <Button onClick={handleImport} disabled={!selectedFile}>
+                        <Upload className="mr-2 h-4 w-4" />
+                        Importar Recibos
+                      </Button>
+                    </IfCan>
                 </div>
 
                 {showStructure && (
@@ -532,9 +544,19 @@ export default function ConciliacionClient() {
                               <TableCell>{column.name}</TableCell>
                               <TableCell>{column.column}</TableCell>
                               <TableCell className="text-right">
-                                <Button variant="secondary" size="sm" onClick={() => handleEditColumn(column)}>
-                                  Editar
-                                </Button>
+                                <IfCan
+                                  routePath={ROUTES.conciliacion}
+                                  action="edit"
+                                  mode="disable"
+                                >
+                                  <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={() => handleEditColumn(column)}
+                                  >
+                                    Editar
+                                  </Button>
+                                </IfCan>
                               </TableCell>
                             </TableRow>
                           ))}

--- a/app/finanzas/conciliacion/page.tsx
+++ b/app/finanzas/conciliacion/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next"
 import ConciliacionClient from "./conciliacion-client"
+import RouteGuard from "@/permissions/RouteGuard"
+import { ROUTES } from "@/constants/routes"
 
 export const metadata: Metadata = {
   title: "Conciliación de Pagos | Blue Atlas",
@@ -7,6 +9,10 @@ export const metadata: Metadata = {
 }
 
 export default function ConciliacionPage() {
-  return <ConciliacionClient />
+  return (
+    <RouteGuard routePath={ROUTES.conciliacion}>
+      <ConciliacionClient />
+    </RouteGuard>
+  )
 }
 

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -4,9 +4,9 @@ import React, { useState, useEffect } from "react"
 import { Menu, X } from "lucide-react"
 import { usePathname, useRouter } from "next/navigation"
 import Sidebar from "@/components/layout/sidebar"
-import ProtectedRoute from "@/components/ProtectedRoute"
 import { cn } from "@/lib/utils"
 import { Toaster } from "@/components/ui/toaster"
+import { PermissionsProvider, usePermissions } from "@/permissions/PermissionsProvider"
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
@@ -15,6 +15,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const [isMobile, setIsMobile] = useState(false)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [userName, setUserName] = useState<string>("")
+  const [ids, setIds] = useState<{ userId: number; roleId: number } | null>(null)
 
   // Verificar autenticación y obtener el nombre del usuario
   useEffect(() => {
@@ -40,6 +41,15 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
     checkIfMobile()
     window.addEventListener("resize", checkIfMobile)
     return () => window.removeEventListener("resize", checkIfMobile)
+  }, [])
+
+  useEffect(() => {
+    const uid = Number(localStorage.getItem("userId"))
+    const user = JSON.parse(localStorage.getItem("user") || "{}")
+    const rid = user.role_id ?? user.roleId
+    if (uid && rid) {
+      setIds({ userId: uid, roleId: rid })
+    }
   }, [])
 
   const handleOverlayClick = () => {
@@ -102,9 +112,13 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                 isMobile ? "w-full" : "lg:ml-0"
               )}
             >
-              <ProtectedRoute>
-                <div className="p-4 md:p-6">{children}</div>
-              </ProtectedRoute>
+              {ids && (
+                <PermissionsProvider userId={ids.userId} roleId={ids.roleId}>
+                  <PermissionsGate>
+                    <div className="p-4 md:p-6">{children}</div>
+                  </PermissionsGate>
+                </PermissionsProvider>
+              )}
             </main>
           </div>
 
@@ -113,4 +127,16 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
       )}
     </>
   )
+}
+
+function PermissionsGate({ children }: { children: React.ReactNode }) {
+  const { loading, error, refresh } = usePermissions()
+  if (loading) return <div className="p-4">Cargando permisos...</div>
+  if (error)
+    return (
+      <div className="p-4">
+        Error al cargar permisos. <button onClick={refresh}>Reintentar</button>
+      </div>
+    )
+  return <>{children}</>
 }

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -1,0 +1,6 @@
+export const ROUTES = {
+  conciliacion: "/finanzas/conciliacion",
+  // TODO: add other routes here
+} as const;
+
+export type RouteKey = keyof typeof ROUTES;

--- a/permissions/IfCan.tsx
+++ b/permissions/IfCan.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+import { useCan, Action } from "./PermissionsProvider";
+
+interface Props {
+  routePath: string;
+  action: Action;
+  mode?: "hide" | "disable";
+  children: React.ReactElement;
+}
+
+const IfCan: React.FC<Props> = ({ routePath, action, mode = "hide", children }) => {
+  const allowed = useCan(routePath, action);
+
+  if (allowed) return children;
+  if (mode === "disable") {
+    return React.cloneElement(children, { disabled: true });
+  }
+  return null;
+};
+
+export default IfCan;

--- a/permissions/PermissionsProvider.tsx
+++ b/permissions/PermissionsProvider.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import api from "@/utils/api";
+
+export type Action = "view" | "create" | "edit" | "delete" | "export";
+
+interface PermissionsContextValue {
+  loading: boolean;
+  error: string | null;
+  hasView: (routePath: string) => boolean;
+  can: (routePath: string, action: Action) => boolean;
+  refresh: () => void;
+}
+
+const PermissionsContext = createContext<PermissionsContextValue>({
+  loading: true,
+  error: null,
+  hasView: () => false,
+  can: () => false,
+  refresh: () => {},
+});
+
+interface ProviderProps {
+  userId: number;
+  roleId: number;
+  useCache?: boolean;
+  children: React.ReactNode;
+}
+
+export const PermissionsProvider: React.FC<ProviderProps> = ({
+  userId,
+  roleId,
+  useCache = true,
+  children,
+}) => {
+  const [viewsAllowed, setViewsAllowed] = useState<Set<string>>(new Set());
+  const [actionsByRoute, setActionsByRoute] = useState<
+    Map<string, Set<Action>>
+  >(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (useCache) {
+        const cachedViews = localStorage.getItem("perm.viewsAllowed");
+        const cachedActions = localStorage.getItem("perm.actionsByRoute");
+        if (cachedViews && cachedActions) {
+          setViewsAllowed(new Set(JSON.parse(cachedViews)));
+          const parsed: Record<string, Action[]> = JSON.parse(cachedActions);
+          const map = new Map<string, Set<Action>>();
+          Object.entries(parsed).forEach(([k, v]) => map.set(k, new Set(v)));
+          setActionsByRoute(map);
+        }
+      }
+
+      const [userPermsRes, rolePermsRes, moduleViewsRes] =
+        await Promise.allSettled([
+          api.get("/userpermissions", { params: { user_id: userId } }),
+          api.get(`/roles/${roleId}/permissions`),
+          api.get("/moduleviews"),
+        ]);
+
+      const mvIndex: Record<number, string> = {};
+      if (moduleViewsRes.status === "fulfilled") {
+        const list = moduleViewsRes.value.data?.data || moduleViewsRes.value.data || [];
+        list.forEach((mv: any) => {
+          if (mv && mv.id != null && mv.view_path) {
+            mvIndex[mv.id] = mv.view_path;
+          }
+        });
+      }
+
+      const viewsSet = new Set<string>();
+      if (userPermsRes.status === "fulfilled") {
+        const permData = userPermsRes.value.data?.data || [];
+        permData.forEach((up: any) => {
+          const id = up.permission_id || up.permission?.views?.[0]?.id;
+          let path = mvIndex[id];
+          if (!path) {
+            path =
+              up.permission?.module?.views?.[0]?.view_path ||
+              up.permission?.views?.[0]?.view_path;
+          }
+          if (path) {
+            viewsSet.add(path);
+          }
+        });
+      }
+
+      const actionsMap = new Map<string, Set<Action>>();
+      if (rolePermsRes.status === "fulfilled") {
+        const items = rolePermsRes.value.data || [];
+        items.forEach((item: any) => {
+          const route = item.view_path;
+          const set = new Set<Action>();
+          const perms = item.permissions || {};
+          (Object.keys(perms) as Action[]).forEach((act) => {
+            if (perms[act]) set.add(act);
+          });
+          actionsMap.set(route, set);
+        });
+      }
+
+      setViewsAllowed(viewsSet);
+      setActionsByRoute(actionsMap);
+
+      if (useCache) {
+        localStorage.setItem(
+          "perm.viewsAllowed",
+          JSON.stringify(Array.from(viewsSet))
+        );
+        const obj: Record<string, Action[]> = {};
+        actionsMap.forEach((v, k) => {
+          obj[k] = Array.from(v);
+        });
+        localStorage.setItem("perm.actionsByRoute", JSON.stringify(obj));
+      }
+    } catch (err: any) {
+      setError(err.message || "Error al cargar permisos");
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, roleId, useCache]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const hasView = useCallback(
+    (routePath: string) => viewsAllowed.has(routePath),
+    [viewsAllowed]
+  );
+
+  const can = useCallback(
+    (routePath: string, action: Action) => {
+      if (!hasView(routePath)) return false;
+      return actionsByRoute.get(routePath)?.has(action) ?? false;
+    },
+    [hasView, actionsByRoute]
+  );
+
+  return (
+    <PermissionsContext.Provider
+      value={{ loading, error, hasView, can, refresh: load }}
+    >
+      {children}
+    </PermissionsContext.Provider>
+  );
+};
+
+export const usePermissions = () => useContext(PermissionsContext);
+
+export const useHasView = (routePath: string) => {
+  const { hasView } = usePermissions();
+  return hasView(routePath);
+};
+
+export const useCan = (routePath: string, action: Action) => {
+  const { can } = usePermissions();
+  return can(routePath, action);
+};
+
+export default PermissionsProvider;

--- a/permissions/README.md
+++ b/permissions/README.md
@@ -1,0 +1,12 @@
+# Permissions Layer
+
+This folder provides a unified permissions layer for the dashboard. The
+`PermissionsProvider` fetches view and action permissions from the API and
+exposes helpers through React context. Use `hasView` to guard routes and
+`can` to enable or disable specific actions. Data is cached in
+`localStorage` to avoid flicker during reloads.
+
+Wrap your application with `PermissionsProvider`, protect pages with
+`<RouteGuard routePath={ROUTES.somePath}>` and wrap buttons with
+`<IfCan routePath={ROUTES.somePath} action="edit">` to hide or disable them
+when the user lacks permissions.

--- a/permissions/RouteGuard.tsx
+++ b/permissions/RouteGuard.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useHasView } from "./PermissionsProvider";
+
+interface Props {
+  routePath: string;
+  children: React.ReactNode;
+}
+
+const RouteGuard: React.FC<Props> = ({ routePath, children }) => {
+  const router = useRouter();
+  const allowed = useHasView(routePath);
+
+  useEffect(() => {
+    if (!allowed) {
+      router.replace("/sin-acceso");
+    }
+  }, [allowed, router]);
+
+  if (!allowed) return null;
+  return <>{children}</>;
+};
+
+export default RouteGuard;

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { API_BASE_URL } from './apiConfig';
+
+const api = axios.create({
+  baseURL: `${API_BASE_URL}/api`,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+api.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response?.status === 401) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('token');
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;


### PR DESCRIPTION
## Summary
- add context-based permission provider with helpers
- create IfCan and RouteGuard components
- integrate provider and guards into conciliation module

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React must be in scope when using JSX)*

------
https://chatgpt.com/codex/tasks/task_e_689b72c194e083288fbacfc91ceab2c6