### PR TITLE
feat: add frontend permission layer

### DIFF
--- a/app/finanzas/conciliacion/conciliacion-client.tsx
+++ b/app/finanzas/conciliacion/conciliacion-client.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import type React from "react"
-
-import { useState } from "react"
+import React, { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -26,6 +24,8 @@ import {
   XCircle,
 } from "lucide-react"
 import Link from "next/link"
+import IfCan from "@/permissions/IfCan"
+import { ROUTES } from "@/constants/routes"
 
 export default function ConciliacionClient() {
   const [activeTab, setActiveTab] = useState("pendientes")
@@ -220,10 +220,12 @@ export default function ConciliacionClient() {
                 <CardDescription>Gestione los recibos de pago pendientes de conciliación.</CardDescription>
               </div>
               <div className="flex gap-2">
-                <Button variant="outline" size="sm" onClick={handleExportResults}>
-                  <Download className="mr-2 h-4 w-4" />
-                  Exportar
-                </Button>
+                <IfCan routePath={ROUTES.conciliacion} action="export">
+                  <Button variant="outline" size="sm" onClick={handleExportResults}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Exportar
+                  </Button>
+                </IfCan>
               </div>
             </CardHeader>
             <CardContent>
@@ -314,10 +316,12 @@ export default function ConciliacionClient() {
                 <CardTitle>Recibos Conciliados</CardTitle>
                 <CardDescription>Historial de recibos de pago conciliados.</CardDescription>
               </div>
-              <Button variant="outline" size="sm" onClick={handleExportResults}>
-                <Download className="mr-2 h-4 w-4" />
-                Exportar
-              </Button>
+                <IfCan routePath={ROUTES.conciliacion} action="export">
+                  <Button variant="outline" size="sm" onClick={handleExportResults}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Exportar
+                  </Button>
+                </IfCan>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between mb-4">
@@ -386,10 +390,12 @@ export default function ConciliacionClient() {
                 <CardTitle>Recibos Rechazados</CardTitle>
                 <CardDescription>Historial de recibos de pago rechazados.</CardDescription>
               </div>
-              <Button variant="outline" size="sm" onClick={handleExportResults}>
-                <Download className="mr-2 h-4 w-4" />
-                Exportar
-              </Button>
+                <IfCan routePath={ROUTES.conciliacion} action="export">
+                  <Button variant="outline" size="sm" onClick={handleExportResults}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Exportar
+                  </Button>
+                </IfCan>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between mb-4">
@@ -484,11 +490,13 @@ export default function ConciliacionClient() {
                         </Button>
                       </div>
                     </div>
-                    {selectedFile && (
-                      <Button variant="outline" onClick={() => setSelectedFile(null)}>
-                        Eliminar
-                      </Button>
-                    )}
+                      {selectedFile && (
+                        <IfCan routePath={ROUTES.conciliacion} action="delete">
+                          <Button variant="outline" onClick={() => setSelectedFile(null)}>
+                            Eliminar
+                          </Button>
+                        </IfCan>
+                      )}
                   </div>
                 </div>
 
@@ -506,10 +514,12 @@ export default function ConciliacionClient() {
                       </>
                     )}
                   </Button>
-                  <Button onClick={handleImport} disabled={!selectedFile}>
-                    <Upload className="mr-2 h-4 w-4" />
-                    Importar Recibos
-                  </Button>
+                    <IfCan routePath={ROUTES.conciliacion} action="create">
+                      <Button onClick={handleImport} disabled={!selectedFile}>
+                        <Upload className="mr-2 h-4 w-4" />
+                        Importar Recibos
+                      </Button>
+                    </IfCan>
                 </div>
 
                 {showStructure && (
@@ -532,9 +542,19 @@ export default function ConciliacionClient() {
                               <TableCell>{column.name}</TableCell>
                               <TableCell>{column.column}</TableCell>
                               <TableCell className="text-right">
-                                <Button variant="secondary" size="sm" onClick={() => handleEditColumn(column)}>
-                                  Editar
-                                </Button>
+                                <IfCan
+                                  routePath={ROUTES.conciliacion}
+                                  action="edit"
+                                  mode="disable"
+                                >
+                                  <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={() => handleEditColumn(column)}
+                                  >
+                                    Editar
+                                  </Button>
+                                </IfCan>
                               </TableCell>
                             </TableRow>
                           ))}

--- a/app/finanzas/conciliacion/page.tsx
+++ b/app/finanzas/conciliacion/page.tsx
@@ -1,5 +1,8 @@
+import React from "react"
 import type { Metadata } from "next"
 import ConciliacionClient from "./conciliacion-client"
+import RouteGuard from "@/permissions/RouteGuard"
+import { ROUTES } from "@/constants/routes"
 
 export const metadata: Metadata = {
   title: "Conciliación de Pagos | Blue Atlas",
@@ -7,6 +10,10 @@ export const metadata: Metadata = {
 }
 
 export default function ConciliacionPage() {
-  return <ConciliacionClient />
+  return (
+    <RouteGuard routePath={ROUTES.conciliacion}>
+      <ConciliacionClient />
+    </RouteGuard>
+  )
 }
 

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -4,9 +4,9 @@ import React, { useState, useEffect } from "react"
 import { Menu, X } from "lucide-react"
 import { usePathname, useRouter } from "next/navigation"
 import Sidebar from "@/components/layout/sidebar"
-import ProtectedRoute from "@/components/ProtectedRoute"
 import { cn } from "@/lib/utils"
 import { Toaster } from "@/components/ui/toaster"
+import { PermissionsProvider, usePermissions } from "@/permissions/PermissionsProvider"
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
@@ -15,6 +15,8 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const [isMobile, setIsMobile] = useState(false)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [userName, setUserName] = useState<string>("")
+  const [ids, setIds] = useState<{ userId: number; roleId: number } | null>(null)
+  const [superAdmin, setSuperAdmin] = useState(false)
 
   // Verificar autenticación y obtener el nombre del usuario
   useEffect(() => {
@@ -40,6 +42,18 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
     checkIfMobile()
     window.addEventListener("resize", checkIfMobile)
     return () => window.removeEventListener("resize", checkIfMobile)
+  }, [])
+
+  useEffect(() => {
+    const uid = Number(localStorage.getItem("userId"))
+    const user = JSON.parse(localStorage.getItem("user") || "{}")
+    const rid = user.role_id ?? user.roleId
+    if (uid && rid) {
+      setIds({ userId: uid, roleId: rid })
+      const isSuper =
+        user.role_name?.toLowerCase() === "admin" || user.is_superuser === true
+      setSuperAdmin(Boolean(isSuper))
+    }
   }, [])
 
   const handleOverlayClick = () => {
@@ -102,15 +116,39 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                 isMobile ? "w-full" : "lg:ml-0"
               )}
             >
-              <ProtectedRoute>
-                <div className="p-4 md:p-6">{children}</div>
-              </ProtectedRoute>
+              {ids && (
+                <PermissionsProvider
+                  userId={ids.userId}
+                  roleId={ids.roleId}
+                  superAdmin={superAdmin}
+                  strictMode={false}
+                >
+                  <PermissionsGate>
+                    <div className="p-4 md:p-6">{children}</div>
+                  </PermissionsGate>
+                </PermissionsProvider>
+              )}
             </main>
           </div>
 
           <Toaster />
         </div>
       )}
+    </>
+  )
+}
+
+function PermissionsGate({ children }: { children: React.ReactNode }) {
+  const { loading, error, refresh } = usePermissions()
+  if (loading) return <div className="p-4">Cargando permisos...</div>
+  return (
+    <>
+      {error && (
+        <div className="p-4">
+          Error al cargar permisos. <button onClick={refresh}>Reintentar</button>
+        </div>
+      )}
+      {children}
     </>
   )
 }

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -1,0 +1,6 @@
+export const ROUTES = {
+  conciliacion: "/finanzas/conciliacion",
+  // TODO: add other routes here
+} as const;
+
+export type RouteKey = keyof typeof ROUTES;

--- a/permissions/IfCan.tsx
+++ b/permissions/IfCan.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+import { useCan, Action } from "./PermissionsProvider";
+
+interface Props {
+  routePath: string;
+  action: Action;
+  mode?: "hide" | "disable";
+  children: React.ReactElement;
+}
+
+const IfCan: React.FC<Props> = ({ routePath, action, mode = "hide", children }) => {
+  const allowed = useCan(routePath, action);
+
+  if (allowed) return children;
+  if (mode === "disable") {
+    return React.cloneElement(children, { disabled: true });
+  }
+  return null;
+};
+
+export default IfCan;

--- a/permissions/PermissionsProvider.tsx
+++ b/permissions/PermissionsProvider.tsx
@@ -1,0 +1,259 @@
+"use client"
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+import api from "@/utils/api"
+
+export type Action = "view" | "create" | "edit" | "delete" | "export"
+
+type RolePermissionItem = {
+  moduleview_id: number
+  menu: string
+  submenu: string
+  view_path: string
+  permissions: Record<Action, boolean>
+}
+
+type UserPermissionRecord = {
+  id: number
+  user_id: number
+  permission_id: number
+  assigned_at: string
+  scope: string
+  permission?: any
+}
+
+type Normalized = {
+  viewsAllowed: Set<string>
+  actionsByRoute: Map<string, Set<Action>>
+}
+
+type Ctx = Normalized & {
+  loading: boolean
+  error: string | null
+  hasView: (routePath: string) => boolean
+  can: (routePath: string, action: Action) => boolean
+  refresh: () => Promise<void>
+}
+
+const PERM_CACHE_VERSION = "2"
+
+const PermissionsContext = createContext<Ctx | null>(null)
+
+export function normalizeRoute(path: string) {
+  try {
+    if (path.startsWith("http")) {
+      const u = new URL(path)
+      path = u.pathname
+    }
+  } catch {}
+  let p = (path || "").trim().toLowerCase()
+  p = p.split("?")[0].split("#")[0]
+  p = p.replace(/\/{2,}/g, "/")
+  if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1)
+  return p
+}
+
+function matchesRoute(candidate: string, target: string) {
+  const c = normalizeRoute(candidate)
+  const t = normalizeRoute(target)
+  if (c === t) return true
+  if (t.startsWith(c + "/")) return true
+  return false
+}
+
+type ProviderProps = {
+  userId: number
+  roleId: number
+  children: React.ReactNode
+  strictMode?: boolean
+  superAdmin?: boolean
+  useCache?: boolean
+}
+
+export const PermissionsProvider: React.FC<ProviderProps> = ({
+  userId,
+  roleId,
+  children,
+  strictMode = false,
+  superAdmin = false,
+  useCache = true,
+}) => {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [viewsAllowed, setViewsAllowed] = useState<Set<string>>(new Set())
+  const [actionsByRoute, setActionsByRoute] = useState<
+    Map<string, Set<Action>>
+  >(new Map())
+  const [moduleviewsIndex, setModuleviewsIndex] = useState<
+    Map<number, { id: number; view_path: string }>
+  >(new Map())
+
+  async function fetchModuleviewsIndex() {
+    try {
+      const res = await api.get("/moduleviews")
+      const list = res.data?.data ?? res.data ?? []
+      const map = new Map<number, { id: number; view_path: string }>()
+      for (const mv of list) {
+        if (mv?.id && mv?.view_path)
+          map.set(Number(mv.id), { id: Number(mv.id), view_path: String(mv.view_path) })
+      }
+      setModuleviewsIndex(map)
+    } catch {
+      // si no existe endpoint, seguimos sin índice
+    }
+  }
+
+  async function fetchAll() {
+    setLoading(true)
+    setError(null)
+    try {
+      if (useCache && localStorage.getItem("perm.version") !== PERM_CACHE_VERSION) {
+        localStorage.removeItem("perm.viewsAllowed")
+        localStorage.removeItem("perm.actionsByRoute")
+        localStorage.setItem("perm.version", PERM_CACHE_VERSION)
+      }
+
+      const [userRes, roleRes] = await Promise.all([
+        api.get("/userpermissions", { params: { user_id: userId } }),
+        api.get(`/roles/${roleId}/permissions`),
+      ])
+
+      if (moduleviewsIndex.size === 0) {
+        await fetchModuleviewsIndex()
+      }
+
+      const userData: UserPermissionRecord[] = userRes.data?.data ?? userRes.data ?? []
+      const roleData: RolePermissionItem[] = roleRes.data ?? []
+
+      const vset = new Set<string>()
+      for (const up of userData) {
+        const mvId = Number(up.permission_id)
+        let vp = moduleviewsIndex.get(mvId)?.view_path
+        if (!vp && up.permission?.module?.views?.length) {
+          vp = up.permission.module.views[0]?.view_path
+        }
+        if (vp) vset.add(normalizeRoute(vp))
+      }
+
+      const amap = new Map<string, Set<Action>>()
+      for (const rp of roleData) {
+        const vp = rp?.view_path ? normalizeRoute(rp.view_path) : null
+        if (!vp) continue
+        const set = amap.get(vp) ?? new Set<Action>()
+        ;(["view", "create", "edit", "delete", "export"] as Action[]).forEach((a) => {
+          if (rp.permissions?.[a]) set.add(a)
+        })
+        amap.set(vp, set)
+      }
+
+      if (useCache) {
+        localStorage.setItem("perm.viewsAllowed", JSON.stringify([...vset]))
+        const serializable: Record<string, Action[]> = {}
+        amap.forEach((set, route) => (serializable[route] = [...set]))
+        localStorage.setItem("perm.actionsByRoute", JSON.stringify(serializable))
+      }
+
+      setViewsAllowed(vset)
+      setActionsByRoute(amap)
+
+      if (process.env.NODE_ENV === "development") {
+        // eslint-disable-next-line no-console
+        console.debug("[PERM] viewsAllowed", vset, "[PERM] actionsByRoute", amap)
+      }
+    } catch (e: any) {
+      setError(e?.message ?? "Error cargando permisos")
+      if (process.env.NODE_ENV === "development") console.error("[PERM] error", e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (useCache) {
+      const v = localStorage.getItem("perm.viewsAllowed")
+      const a = localStorage.getItem("perm.actionsByRoute")
+      if (v && a) {
+        const views = new Set<string>(JSON.parse(v))
+        const actionsRaw: Record<string, Action[]> = JSON.parse(a)
+        const actions = new Map<string, Set<Action>>()
+        Object.entries(actionsRaw).forEach(([route, arr]) =>
+          actions.set(route, new Set(arr))
+        )
+        setViewsAllowed(views)
+        setActionsByRoute(actions)
+      }
+    }
+    fetchAll()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, roleId])
+
+  const hasView = useMemo(
+    () => (routePath: string) => {
+      if (superAdmin) return true
+      const route = normalizeRoute(routePath)
+      if (viewsAllowed.has(route)) return true
+      if (!strictMode) {
+        for (const vp of viewsAllowed) {
+          if (matchesRoute(vp, route)) return true
+        }
+      }
+      return false
+    },
+    [viewsAllowed, superAdmin, strictMode]
+  )
+
+  const can = useMemo(
+    () => (routePath: string, action: Action) => {
+      if (superAdmin) return true
+      const route = normalizeRoute(routePath)
+      const viewOk = hasView(route) || (!strictMode && viewsAllowed.size > 0)
+      if (!viewOk) return false
+      const set = actionsByRoute.get(route)
+      if (set?.has(action)) return true
+      if (!strictMode) {
+        for (const [vp, s] of actionsByRoute.entries()) {
+          if (matchesRoute(vp, route) && s.has(action)) return true
+        }
+      }
+      return false
+    },
+    [actionsByRoute, hasView, strictMode, superAdmin, viewsAllowed.size]
+  )
+
+  const value: Ctx = {
+    loading,
+    error,
+    viewsAllowed,
+    actionsByRoute,
+    hasView,
+    can,
+    refresh: fetchAll,
+  }
+
+  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>
+}
+
+export function usePermissions() {
+  const ctx = useContext(PermissionsContext)
+  if (!ctx) throw new Error("usePermissions must be used within PermissionsProvider")
+  return ctx
+}
+
+export function useCan(routePath: string, action: Action) {
+  const { can } = usePermissions()
+  return can(routePath, action)
+}
+
+export function useHasView(routePath: string) {
+  const { hasView } = usePermissions()
+  return hasView(routePath)
+}
+
+export default PermissionsProvider
+

--- a/permissions/README.md
+++ b/permissions/README.md
@@ -1,0 +1,14 @@
+# Permissions Layer
+
+This folder provides a unified permissions layer for the dashboard. The
+`PermissionsProvider` fetches view and action permissions from the API and
+exposes helpers through React context. Use `hasView` to guard routes and
+`can` to enable or disable specific actions. Data is cached in
+`localStorage` to avoid flicker during reloads. A `superAdmin` flag can
+bypass all checks and `strictMode` toggles between a permissive SAFE mode
+and strict blocking.
+
+Wrap your application with `PermissionsProvider`, protect pages with
+`<RouteGuard routePath={ROUTES.somePath}>` and wrap buttons with
+`<IfCan routePath={ROUTES.somePath} action="edit">` to hide or disable them
+when the user lacks permissions.

--- a/permissions/RouteGuard.tsx
+++ b/permissions/RouteGuard.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import React from "react"
+import { useRouter } from "next/navigation"
+import { usePermissions } from "./PermissionsProvider"
+
+type Props = {
+  routePath: string
+  children: React.ReactNode
+  strictMode?: boolean
+}
+
+const RouteGuard: React.FC<Props> = ({ routePath, children, strictMode = false }) => {
+  const { loading, error, hasView } = usePermissions()
+  const router = useRouter()
+
+  if (loading) return <div className="p-6">Cargando permisos…</div>
+
+  if (strictMode) {
+    if (error) return <div className="p-6">No se pudieron cargar permisos.</div>
+    if (!hasView(routePath)) {
+      router.replace("/sin-acceso")
+      return null
+    }
+  }
+
+  return <>{children}</>
+}
+
+export default RouteGuard
+

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { API_BASE_URL } from './apiConfig';
+
+const api = axios.create({
+  baseURL: `${API_BASE_URL}/api`,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+api.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response?.status === 401) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('token');
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;


### PR DESCRIPTION
## Summary
- add context-based permission provider with helpers
- create IfCan and RouteGuard components
- integrate provider and guards into conciliation module
- stabilize permission layer with super admin bypass, safe mode, and normalized route matching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'React' must be in scope when using JSX)*

------
https://chatgpt.com/codex/tasks/task_e_689b72c194e083288fbacfc91ceab2c6