### PR TITLE
feat: add contract preview and signature submission

### DIFF
--- a/components/firma/student-details.tsx
+++ b/components/firma/student-details.tsx
@@ -4,9 +4,6 @@ import React, { useState, useEffect, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,135 +14,74 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { CheckCircle, ZoomIn, ZoomOut, RotateCw, Loader2 } from "lucide-react"
-import Swal from 'sweetalert2'
-import { API_BASE_URL } from '@/utils/apiConfig'
+import { Loader2, CheckCircle } from "lucide-react"
+import { API_BASE_URL } from "@/utils/apiConfig"
+import { getSignatureDataUri } from "@/utils/getSignatureDataUri"
+import { fetchWithAuth } from "@/utils/fetchWithAuth"
 
-interface Student {
-  id: string
-  name: string
-  email: string
-}
-interface ProgramaItem {
-  id: number
-  prospecto_id: number
-  inscripcion: string
-  cuota_mensual: string | null       // puede ser null
-  convenio_id: number | null         // lo mismo
-  programa: {
-    id: number
-    abreviatura: string
-    nombre_del_programa: string
-    meses: number
-  }
+interface PreviewData {
+  prospecto: { id: number; nombre: string; correo: string }
+  asesor: { id: number; nombre: string; correo: string }
+  programa: { id: number; abreviatura: string; nombre: string }
+  montos: { inscripcion: number; mensualidad: number; convenio_id: number | null }
+  fecha: string
 }
 
-interface User {
-  id: number
-  first_name: string
-  last_name: string
-  username: string
-  email: string
+interface SuccessResponse {
+  message: string
+  pdf_url: string
+  signature_url: string
+  contract_id: number
 }
 
 export function StudentDetails() {
-  const { id: studentId } = useParams()
+  const { id } = useParams()
   const router = useRouter()
 
-  const [student, setStudent] = useState<Student | null>(null)
-  const [programas, setProgramas] = useState<ProgramaItem[]>([])
-  const [currentUser, setCurrentUser] = useState<User | null>(null)
-  const [signature, setSignature] = useState<string | null>(null)
+  const [preview, setPreview] = useState<PreviewData | null>(null)
+  const [loadingPreview, setLoadingPreview] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [isDrawing, setIsDrawing] = useState(false)
   const [lastX, setLastX] = useState(0)
   const [lastY, setLastY] = useState(0)
+  const [signature, setSignature] = useState<string | null>(null)
 
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [showSuccessDialog, setShowSuccessDialog] = useState(false)
-  const [zoomLevel, setZoomLevel] = useState(100)
+  const [successData, setSuccessData] = useState<SuccessResponse | null>(null)
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
-  // Alias al primer programa (si existe)
-  const programa = programas[0]
-
-  // Fecha formateada una vez para coincidir con PDF
-  const formattedDate = new Date().toLocaleDateString("es-GT", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  })
-
-  // 1) Traer prospecto
+  // Fetch preview data
   useEffect(() => {
-    if (!studentId) return
-      ; (async () => {
-        try {
-          const token = localStorage.getItem("token")
-          const res = await fetch(
-            `${API_BASE_URL}/api/prospectos/${studentId}`,
-            { headers: { Authorization: `Bearer ${token}` } }
-          )
-          const json = await res.json()
-          console.log("Prospecto recibido:", json.data)
-          setStudent({
-            id: String(json.data.id),
-            name: json.data.nombre_completo,
-            email:
-              json.data.correo_electronico ||
-              json.data.correo ||
-              json.data.email ||
-              "",
-          })
-        } catch (err) {
-          console.error(err)
-        }
-      })()
-  }, [studentId])
-
-  // 2) Traer programas del prospecto
-  useEffect(() => {
-    if (!studentId) return
-      ; (async () => {
-        try {
-          const token = localStorage.getItem("token")
-          const res = await fetch(
-            `${API_BASE_URL}/api/estudiante-programa?prospecto_id=${studentId}`,
-            { headers: { Authorization: `Bearer ${token}` } }
-          )
-          if (!res.ok) throw new Error("Error al cargar programas")
-          const data: ProgramaItem[] = await res.json()
-          console.log("Programas recibidos:", data)
-          setProgramas(data)
-        } catch (err) {
-          console.error(err)
-        }
-      })()
-  }, [studentId])
-
-  // 3) Traer usuario autenticado
-  useEffect(() => {
-    ; (async () => {
+    if (!id) return
+    ;(async () => {
       try {
-        const token = localStorage.getItem("token")
-        const res = await fetch(`${API_BASE_URL}/api/user`, {
-          headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
-        })
-        const user: User = await res.json()
-        console.log("Usuario recibido:", user)
-        setCurrentUser(user)
-        setStudent((prev) =>
-          prev ? { ...prev, email: prev.email || user.email } : prev
+        const res = await fetchWithAuth(
+          `${API_BASE_URL}/api/prospectos/${id}/contrato/preview`
         )
-      } catch (err) {
-        console.error(err)
+        if (!res.ok) {
+          switch (res.status) {
+            case 401:
+              throw new Error("No autorizado")
+            case 404:
+              throw new Error("Prospecto no encontrado")
+            default:
+              throw new Error("Error al cargar el contrato")
+          }
+        }
+        const data: PreviewData = await res.json()
+        setPreview(data)
+      } catch (err: any) {
+        setError(err.message || "Error desconocido")
+      } finally {
+        setLoadingPreview(false)
       }
     })()
-  }, [])
+  }, [id])
 
-  // 4) Inicializar canvas
+  // Initialize canvas
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
@@ -156,7 +92,7 @@ export function StudentDetails() {
     ctx.lineCap = "round"
   }, [])
 
-  // 5) Handlers de dibujo
+  // Drawing handlers
   const startDrawing = (e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = canvasRef.current
     if (!canvas) return
@@ -169,9 +105,8 @@ export function StudentDetails() {
     const ctx = canvas.getContext("2d")
     ctx?.beginPath()
     ctx?.moveTo(x, y)
-    ctx?.lineTo(x, y)
-    ctx?.stroke()
   }
+
   const draw = (e: React.MouseEvent<HTMLCanvasElement>) => {
     if (!isDrawing) return
     const canvas = canvasRef.current
@@ -180,19 +115,18 @@ export function StudentDetails() {
     const rect = canvas.getBoundingClientRect()
     const x = e.clientX - rect.left
     const y = e.clientY - rect.top
-    ctx.beginPath()
-    ctx.moveTo(lastX, lastY)
     ctx.lineTo(x, y)
     ctx.stroke()
     setLastX(x)
     setLastY(y)
   }
+
   const stopDrawing = () => {
     if (!isDrawing) return
     setIsDrawing(false)
-    const canvas = canvasRef.current
-    if (canvas) setSignature(canvas.toDataURL())
+    setSignature(getSignatureDataUri(canvasRef.current))
   }
+
   const clearSignature = () => {
     const canvas = canvasRef.current
     const ctx = canvas?.getContext("2d")
@@ -202,82 +136,51 @@ export function StudentDetails() {
     }
   }
 
-  // 6) Zoom handlers
-  const increaseZoom = () => zoomLevel < 200 && setZoomLevel(z => z + 10)
-  const decreaseZoom = () => zoomLevel > 50 && setZoomLevel(z => z - 10)
-  const resetZoom = () => setZoomLevel(100)
-
-  // 7) Envío del contrato
   const handleSendContract = () => {
     if (!signature) {
       alert("Por favor, firme el contrato antes de enviarlo.")
       return
     }
-    if (!currentUser?.email) {
-      alert("No se pudo obtener el correo del usuario.")
-      return
-    }
     setShowConfirmDialog(true)
   }
+
   const confirmSendContract = async () => {
     setShowConfirmDialog(false)
     setLoading(true)
     setError(null)
     try {
-      const token = localStorage.getItem("token")
-      const res = await fetch(
-        `${API_BASE_URL}/api/prospectos/${studentId}/enviar-contrato`,
+      const res = await fetchWithAuth(
+        `${API_BASE_URL}/api/prospectos/${id}/enviar-contrato`,
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-          body: JSON.stringify({
-            signature,
-            email: currentUser?.email || student?.email,
-            prospecto: student?.name,
-            programa: programa?.programa.nombre_del_programa,
-            matricula: programa?.inscripcion,
-            mensualidad: programa?.cuota_mensual,
-            asesor: currentUser
-              ? `${currentUser.first_name} ${currentUser.last_name}`
-              : "",
-            fecha: formattedDate,
-          }),
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ signature }),
         }
       )
+      if (res.status === 409) {
+        setError("Este prospecto ya recibió el contrato hoy.")
+        return
+      }
       if (!res.ok) {
         const text = await res.text()
-        throw new Error(text || res.statusText)
+        throw new Error(text || "Error al enviar contrato")
       }
-      await res.json()
+      const data: SuccessResponse = await res.json()
+      setSuccessData(data)
       setShowSuccessDialog(true)
     } catch (err: any) {
-      // Si ya se envió hoy, código 23505 en PG => uniq violation
-      if (err.message.includes("ux_contactos_env_prosp_canal_dia")) {
-        Swal.fire({
-          icon: "warning",
-          title: "Contrato ya enviado",
-          text: "Este prospecto ya recibió el contrato hoy.",
-        })
-      } else {
-        setError(err.message || "Error desconocido")
-      }
+      setError(err.message || "Error desconocido")
     } finally {
       setLoading(false)
     }
   }
 
-  // 8) Cerrar diálogo de éxito
   const handleSuccessClose = () => {
     setShowSuccessDialog(false)
     router.push("/firma")
   }
 
-  // 8) Loading states
-  if (!student || programas.length === 0 || !currentUser) {
+  if (loadingPreview) {
     return (
       <div className="flex items-center justify-center h-64">
         <Loader2 className="animate-spin h-12 w-12 text-gray-500" />
@@ -285,172 +188,32 @@ export function StudentDetails() {
     )
   }
 
-  // 9) Render completo
+  if (error && !preview) {
+    return <p className="text-red-500 text-center">{error}</p>
+  }
+
+  if (!preview) return null
+
   return (
     <div className="space-y-6">
-      {/* Prospecto */}
-      <p className="text-sm font-medium text-blue-600">
-        ID Estudiante: {student.id}
-      </p>
-      <p className="text-lg font-semibold mb-4">{student.name}</p>
-      <div className="mb-4 max-w-md">
-        <Label htmlFor="email">Correo electrónico</Label>
-        <Input id="email" value={currentUser?.email || student.email} readOnly />
-      </div>
-
       <Card>
-        <CardHeader className="flex justify-between items-center">
+        <CardHeader>
           <CardTitle>Contrato de Confidencialidad</CardTitle>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="icon" onClick={decreaseZoom}>
-              <ZoomOut />
-            </Button>
-            <span>{zoomLevel}%</span>
-            <Button variant="outline" size="icon" onClick={increaseZoom}>
-              <ZoomIn />
-            </Button>
-            <Button variant="outline" size="icon" onClick={resetZoom}>
-              <RotateCw />
-            </Button>
-          </div>
         </CardHeader>
-
         <CardContent className="space-y-4">
-          <div className="prose space-y-2" style={{ zoom: `${zoomLevel}%` }}>
-            <p className="font-bold">
-              CONTRATO DE CONFIDENCIALIDAD Y COMPROMISO DE ESTUDIANTE
-            </p>
-            <p>(Por favor firme ambas páginas en donde corresponde)</p>
+          <div className="space-y-2">
             <p>
-              En la ciudad de Guatemala, el día: {formattedDate}
+              Yo: <strong>{preview.prospecto.nombre}</strong> ({preview.prospecto.correo}) y
+              Asesor: <strong>{preview.asesor.nombre}</strong> ({preview.asesor.correo})
             </p>
             <p>
-              Yo: <strong>{student.name}</strong>{" "}
-              {student.email && <span>({student.email})</span>} &nbsp;&nbsp;Firma:
-              __________________________
+              Programa: <strong>{preview.programa.nombre}</strong> ({preview.programa.abreviatura})
             </p>
-            <p>
-              Me comprometo a mantener de manera estrictamente confidencial los
-              precios corporativos otorgados por American School of Management para
-              cursar mi programa de:
-            </p>
-            <p>
-              <strong>
-                {programa.programa.nombre_del_programa} ({programa.programa.abreviatura})
-              </strong>
-            </p>
-            <p>
-              Asimismo, entiendo y acepto que mi participación en el acto de
-              graduación de dicho programa es obligatoria e indispensable.
-            </p>
-
-            {/* Datos económicos */}
-            <p>
-              Matrícula: Q{programa.inscripcion}
-              <br />
-              Mensualidad: Q{programa.cuota_mensual}
-            </p>
-
-            {/* Sección extra sólo si convenio_id y cuota_mensual existen */}
-            {programa.convenio_id != null && programa.cuota_mensual != null && (
-              <p>
-                Asimismo, acepto que, en caso de divulgar este precio y las
-                condiciones preferenciales relacionadas con la duración del programa,
-                perderé automáticamente dicho beneficio y deberé asumir el pago de la
-                cuota vigente correspondiente al tiempo establecido. Cabe destacar
-                que el porcentaje de beca aplica únicamente si el pago se realiza
-                mediante depósito o transferencia bancaria, y no se aplica con otros
-                medios de pago. Si el pago se efectúa por otros medios distintos a
-                los mencionados, la cuota se ajustará de la siguiente manera:
-                <br />
-                <strong>Mensualidad: Q{programa.cuota_mensual}</strong>
-              </p>
-            )}
-
-            {/* Aquí continúa el resto del contrato */}
-            <p>
-              Deseo que el cobro de mi mensualidad sea de manera automática: (El
-              cobro se realizará los primeros días de cada mes, aplicando el
-              porcentaje de beca correspondiente).<br />
-              Sí: ________
-            </p>
-            <p>
-              Confirmo que he recibido toda la información necesaria sobre los
-              requisitos académicos y administrativos para mi programa.
-            </p>
-            <p>
-              Declaro que estoy plenamente informado(a) y de acuerdo con que mi día
-              de estudio puede ser modificado durante el transcurso de la carrera,
-              y que los cursos del área común pueden variar según la programación
-              anual. Reconozco que, al inscribirme, me uniré a un canal de WhatsApp,
-              cuya participación es obligatoria durante toda la duración de mi
-              carrera, con el fin de mantenerme actualizado(a) sobre toda la
-              información relevante.
-            </p>
-            <p>
-              Asimismo, confirmo que estoy consciente de que, debido a la modalidad
-              de estudio de mi programa, es indispensable tomar mis clases a través
-              de una computadora con una conexión a internet estable, en un espacio
-              adecuado, y con la cámara encendida en todo momento.
-            </p>
-            <p>
-              Finalmente, autorizo a American School of Management a utilizar mis
-              fotografías para fines de colaboración institucional en materiales
-              impresos o digitales.
-            </p>
-            <p>
-              Estoy plenamente informado(a) de que el plazo límite para la entrega
-              de los documentos requeridos es durante el primer trimestre del
-              programa. Entiendo que no cumplir con esta entrega dentro del
-              período establecido representará un obstáculo para mi graduación y la
-              emisión del título correspondiente.
-            </p>
-            <p>
-              Reitero mi compromiso de no duplicar ni compartir materiales
-              provenientes de la plataforma para fines distintos a la realización
-              de los cursos. Está estrictamente prohibido replicar rúbricas, casos
-              del CIC o cualquier material proporcionado por Harvard BP, ya que
-              dichas acciones serán consideradas como plagio y estarán sujetas a
-              las consecuencias correspondientes.
-            </p>
-            <p>
-              En American School of Management, los estudiantes se comprometen a la
-              excelencia académica desde el inicio de su programa. Se fomenta la
-              búsqueda de altos promedios para obtener menciones honoríficas:<br />
-              • Cum Laude: promedio de 96 puntos.<br />
-              • Magna Cum Laude: promedio de 97 a 98 puntos.<br />
-              • Summa Cum Laude: promedio de 99 a 100 puntos.
-            </p>
-            <p>
-              Además, se espera que los estudiantes actúen con integridad y ética,
-              siendo un ejemplo de dedicación e inspiración para sus compañeros.
-            </p>
-            <p>
-              Asimismo, acepto que al realizar los pagos correspondientes a las
-              mensualidades y gastos adicionales, me comprometo a enviar las boletas
-              únicamente a las siguientes direcciones: contabilidad@american-edu.com
-              o a los números de WhatsApp +502 4169-8467 o +502 4138-1907. Se
-              exceptúa el pago de inscripción, el cual deberá ser remitido
-              directamente al asesor educativo. Está prohibido enviar boletas a
-              direcciones distintas a las mencionadas anteriormente.
-            </p>
-            <p>
-              Con pleno entendimiento y aceptación de las condiciones aquí
-              establecidas, firmo en señal de conformidad con este contrato.
-            </p>
-            <p>
-              Firma: ____________________ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              Firma: ____________________<br />
-              {student.name} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; {currentUser.first_name}{" "}
-              {currentUser.last_name}
-              <br />
-              Prospecto &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Asesor Educativo
-            </p>
+            <p>Matrícula: Q{preview.montos.inscripcion}</p>
+            <p>Mensualidad: Q{preview.montos.mensualidad}</p>
+            <p>Fecha: {preview.fecha}</p>
           </div>
 
-          <Separator />
-
-          {/* Firma del Asesor */}
           <div className="space-y-2">
             <h4 className="text-sm font-medium">Firma del Asesor</h4>
             <div className="border rounded-lg p-2">
@@ -462,7 +225,7 @@ export function StudentDetails() {
                 onMouseDown={startDrawing}
                 onMouseMove={draw}
                 onMouseUp={stopDrawing}
-                onMouseOut={stopDrawing}
+                onMouseLeave={stopDrawing}
               />
               <div className="mt-2">
                 <Button variant="outline" size="sm" onClick={clearSignature}>
@@ -472,24 +235,24 @@ export function StudentDetails() {
             </div>
           </div>
 
+          {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+
           <Button
-            className="w-full flex justify-center items-center"
+            className="w-full"
             onClick={handleSendContract}
             disabled={!signature || loading}
           >
-            {loading
-              ? <>
-                <Loader2 className="animate-spin h-5 w-5 mr-2" />
-                Enviando...
+            {loading ? (
+              <>
+                <Loader2 className="animate-spin h-5 w-5 mr-2" /> Enviando...
               </>
-              : "Enviar Contrato"
-            }
+            ) : (
+              "Enviar Contrato"
+            )}
           </Button>
-          {error && <p className="text-red-500 text-sm text-center mt-2">{error}</p>}
         </CardContent>
       </Card>
 
-      {/* Confirmación */}
       <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -507,7 +270,6 @@ export function StudentDetails() {
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* Éxito */}
       <AlertDialog open={showSuccessDialog} onOpenChange={setShowSuccessDialog}>
         <AlertDialogContent>
           <AlertDialogHeader className="text-center">
@@ -515,6 +277,29 @@ export function StudentDetails() {
               <CheckCircle className="h-10 w-10 text-green-600 mx-auto" />
             </div>
             <AlertDialogTitle>¡Enviado con éxito!</AlertDialogTitle>
+            {successData && (
+              <AlertDialogDescription className="space-y-2">
+                <p>{successData.message}</p>
+                <p>
+                  <a
+                    href={successData.pdf_url}
+                    target="_blank"
+                    className="text-blue-600 underline"
+                  >
+                    Ver contrato PDF
+                  </a>
+                </p>
+                <p>
+                  <a
+                    href={successData.signature_url}
+                    target="_blank"
+                    className="text-blue-600 underline"
+                  >
+                    Ver firma
+                  </a>
+                </p>
+              </AlertDialogDescription>
+            )}
           </AlertDialogHeader>
           <AlertDialogFooter className="justify-center">
             <AlertDialogAction onClick={handleSuccessClose}>
@@ -526,3 +311,5 @@ export function StudentDetails() {
     </div>
   )
 }
+
+export default StudentDetails

--- a/utils/fetchWithAuth.ts
+++ b/utils/fetchWithAuth.ts
@@ -1,0 +1,10 @@
+export async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
+  const token = typeof window !== "undefined" ? localStorage.getItem("token") : null
+  const headers: HeadersInit = {
+    ...(options.headers || {}),
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  return fetch(url, { ...options, headers })
+}

--- a/utils/getSignatureDataUri.ts
+++ b/utils/getSignatureDataUri.ts
@@ -1,0 +1,4 @@
+export function getSignatureDataUri(canvas: HTMLCanvasElement | null): string | null {
+  if (!canvas) return null
+  return canvas.toDataURL("image/png")
+}


### PR DESCRIPTION
## Summary
- add reusable utilities for authenticated fetch and canvas to data URI
- display contract preview with advisor and prospect data
- capture signature, send to backend, and surface PDF and signature links

## Testing
- `npm run lint` *(fails: React must be in scope when using JSX)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3d111508328aeef653c14e01bc6