### PR TITLE
Add independent filters and pagination to financial reports

### DIFF
--- a/components/finanzas/reportes-financieros.tsx
+++ b/components/finanzas/reportes-financieros.tsx
@@ -16,7 +16,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
-import { Loader2, RefreshCw } from "lucide-react"
+import { useToast } from "@/components/ui/use-toast"
+import { Eye, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
   getCuotasDashboard,
@@ -25,8 +26,10 @@ import {
   type CuotaProgramaResumen,
   type CuotasDashboardEstudiante,
   type CuotasDashboardResponse,
-  type KardexDashboardResponse,
+  type CuotasDashboardMetrics,
+  type KardexDashboardMetrics,
   type KardexPagoResumen,
+  type ReconciliationDashboardMetrics,
   type ReconciliationRecordResumen,
 } from "@/services/mantenimientos"
 
@@ -119,12 +122,39 @@ interface ReportFilters {
   limit: number
 }
 
-const DEFAULT_FILTERS: ReportFilters = {
+const BASE_FILTERS: ReportFilters = {
   search: "",
   estadoPago: "todos",
   estadoReconciliacion: "todos",
   estadoCuota: "todos",
   limit: 50,
+}
+
+type TabKey = "kardex" | "reconciliaciones" | "cuotas"
+type PaginationKey = "kardex" | "reconciliaciones" | "cuotasEstudiantes" | "cuotas"
+
+interface PaginationState {
+  page: number
+  pageSize: number
+}
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100]
+
+const createDefaultFilters = (): ReportFilters => ({
+  ...BASE_FILTERS,
+})
+
+type RowAction = "view" | "edit" | "delete"
+
+const ACTION_LABELS: Record<RowAction, string> = {
+  view: "Ver detalle",
+  edit: "Editar",
+  delete: "Eliminar",
+}
+
+const TAB_LABELS: Record<"kardex" | "reconciliaciones", string> = {
+  kardex: "Kardex",
+  reconciliaciones: "Conciliaciones",
 }
 
 const buildRequestFilters = (filters: ReportFilters) => ({
@@ -136,115 +166,473 @@ const buildRequestFilters = (filters: ReportFilters) => ({
 })
 
 export const ReportesFinancieros = () => {
-  const [activeTab, setActiveTab] = useState("kardex")
-  const [filters, setFilters] = useState<ReportFilters>(DEFAULT_FILTERS)
-  const [formFilters, setFormFilters] = useState<ReportFilters>(DEFAULT_FILTERS)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [dashboardSummary, setDashboardSummary] = useState<KardexDashboardResponse | null>(null)
+  const { toast } = useToast()
+  const [activeTab, setActiveTab] = useState<TabKey>("kardex")
+  const [filtersByTab, setFiltersByTab] = useState<Record<TabKey, ReportFilters>>({
+    kardex: createDefaultFilters(),
+    reconciliaciones: createDefaultFilters(),
+    cuotas: createDefaultFilters(),
+  })
+  const [formFiltersByTab, setFormFiltersByTab] = useState<Record<TabKey, ReportFilters>>({
+    kardex: createDefaultFilters(),
+    reconciliaciones: createDefaultFilters(),
+    cuotas: createDefaultFilters(),
+  })
+  const [loadingStates, setLoadingStates] = useState<Record<TabKey, boolean>>({
+    kardex: false,
+    reconciliaciones: false,
+    cuotas: false,
+  })
+  const [errors, setErrors] = useState<Record<TabKey, string | null>>({
+    kardex: null,
+    reconciliaciones: null,
+    cuotas: null,
+  })
+  const [kardexTotals, setKardexTotals] = useState<KardexDashboardMetrics | null>(null)
+  const [reconciliacionTotals, setReconciliacionTotals] =
+    useState<ReconciliationDashboardMetrics | null>(null)
+  const [cuotasTotals, setCuotasTotals] = useState<CuotasDashboardMetrics | null>(null)
   const [kardexRows, setKardexRows] = useState<KardexPagoResumen[]>([])
   const [reconciliationRows, setReconciliationRows] = useState<ReconciliationRecordResumen[]>([])
   const [cuotasRows, setCuotasRows] = useState<CuotaProgramaResumen[]>([])
   const [cuotasDashboard, setCuotasDashboard] = useState<CuotasDashboardResponse | null>(null)
-  const [lastUpdated, setLastUpdated] = useState<string | null>(null)
-
-  useEffect(() => {
-    setFormFilters(filters)
-  }, [filters])
+  const [kardexLastUpdated, setKardexLastUpdated] = useState<string | null>(null)
+  const [reconciliacionesLastUpdated, setReconciliacionesLastUpdated] =
+    useState<string | null>(null)
+  const [cuotasLastUpdated, setCuotasLastUpdated] = useState<string | null>(null)
+  const [pagination, setPagination] = useState<Record<PaginationKey, PaginationState>>({
+    kardex: { page: 1, pageSize: 10 },
+    reconciliaciones: { page: 1, pageSize: 10 },
+    cuotasEstudiantes: { page: 1, pageSize: 10 },
+    cuotas: { page: 1, pageSize: 10 },
+  })
 
   useEffect(() => {
     const controller = new AbortController()
 
-    const loadData = async () => {
-      setLoading(true)
-      setError(null)
+    const loadKardex = async () => {
+      setLoadingStates((prev) => ({ ...prev, kardex: true }))
+      setErrors((prev) => ({ ...prev, kardex: null }))
 
-      const params = buildRequestFilters(filters)
+      const params = buildRequestFilters(filtersByTab.kardex)
 
       try {
-        const [kardexDashboard, kardexData, cuotasDashboardResponse] = await Promise.all([
+        const [dashboardResponse, dataResponse] = await Promise.all([
           getKardexDashboard(params, { signal: controller.signal }),
           getKardexData(params, { signal: controller.signal }),
-          getCuotasDashboard(params, { signal: controller.signal }),
         ])
 
         if (controller.signal.aborted) {
           return
         }
 
-        setDashboardSummary(kardexDashboard)
-        setKardexRows(kardexData.kardex)
-        setReconciliationRows(kardexData.reconciliaciones)
-        setCuotasRows(kardexData.cuotas)
-        setCuotasDashboard(cuotasDashboardResponse)
-        setLastUpdated(kardexData.timestamp)
+        setKardexTotals(dashboardResponse.kardex)
+        setKardexRows(dataResponse.kardex)
+        setKardexLastUpdated(dataResponse.timestamp)
+        setPagination((prev) => ({
+          ...prev,
+          kardex:
+            prev.kardex.page === 1 ? prev.kardex : { ...prev.kardex, page: 1 },
+        }))
       } catch (err) {
         if ((err as { code?: string })?.code === "ERR_CANCELED") {
           return
         }
 
-        if (axios.isAxiosError(err)) {
-          setError(err.response?.data?.message ?? err.message ?? "No se pudieron cargar los reportes")
-        } else {
-          setError((err as Error).message ?? "No se pudieron cargar los reportes")
-        }
+        const message = axios.isAxiosError(err)
+          ? err.response?.data?.message ?? err.message ??
+            "No se pudieron cargar los movimientos del kardex"
+          : (err as Error).message ??
+            "No se pudieron cargar los movimientos del kardex"
+
+        setErrors((prev) => ({ ...prev, kardex: message }))
       } finally {
         if (!controller.signal.aborted) {
-          setLoading(false)
+          setLoadingStates((prev) => ({ ...prev, kardex: false }))
         }
       }
     }
 
-    loadData()
+    loadKardex()
 
     return () => {
       controller.abort()
     }
-  }, [filters])
+  }, [filtersByTab.kardex])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const loadReconciliaciones = async () => {
+      setLoadingStates((prev) => ({ ...prev, reconciliaciones: true }))
+      setErrors((prev) => ({ ...prev, reconciliaciones: null }))
+
+      const params = buildRequestFilters(filtersByTab.reconciliaciones)
+
+      try {
+        const [dashboardResponse, dataResponse] = await Promise.all([
+          getKardexDashboard(params, { signal: controller.signal }),
+          getKardexData(params, { signal: controller.signal }),
+        ])
+
+        if (controller.signal.aborted) {
+          return
+        }
+
+        setReconciliacionTotals(dashboardResponse.reconciliaciones)
+        setReconciliationRows(dataResponse.reconciliaciones)
+        setReconciliacionesLastUpdated(dataResponse.timestamp)
+        setPagination((prev) => ({
+          ...prev,
+          reconciliaciones:
+            prev.reconciliaciones.page === 1
+              ? prev.reconciliaciones
+              : { ...prev.reconciliaciones, page: 1 },
+        }))
+      } catch (err) {
+        if ((err as { code?: string })?.code === "ERR_CANCELED") {
+          return
+        }
+
+        const message = axios.isAxiosError(err)
+          ? err.response?.data?.message ?? err.message ??
+            "No se pudieron cargar las conciliaciones"
+          : (err as Error).message ?? "No se pudieron cargar las conciliaciones"
+
+        setErrors((prev) => ({ ...prev, reconciliaciones: message }))
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoadingStates((prev) => ({ ...prev, reconciliaciones: false }))
+        }
+      }
+    }
+
+    loadReconciliaciones()
+
+    return () => {
+      controller.abort()
+    }
+  }, [filtersByTab.reconciliaciones])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const loadCuotas = async () => {
+      setLoadingStates((prev) => ({ ...prev, cuotas: true }))
+      setErrors((prev) => ({ ...prev, cuotas: null }))
+
+      const params = buildRequestFilters(filtersByTab.cuotas)
+
+      try {
+        const [dashboardResponse, dataResponse, cuotasDashboardResponse] =
+          await Promise.all([
+            getKardexDashboard(params, { signal: controller.signal }),
+            getKardexData(params, { signal: controller.signal }),
+            getCuotasDashboard(params, { signal: controller.signal }),
+          ])
+
+        if (controller.signal.aborted) {
+          return
+        }
+
+        setCuotasTotals(dashboardResponse.cuotas)
+        setCuotasRows(dataResponse.cuotas)
+        setCuotasLastUpdated(dataResponse.timestamp)
+        setCuotasDashboard(cuotasDashboardResponse)
+        setPagination((prev) => ({
+          ...prev,
+          cuotas:
+            prev.cuotas.page === 1 ? prev.cuotas : { ...prev.cuotas, page: 1 },
+          cuotasEstudiantes:
+            prev.cuotasEstudiantes.page === 1
+              ? prev.cuotasEstudiantes
+              : { ...prev.cuotasEstudiantes, page: 1 },
+        }))
+      } catch (err) {
+        if ((err as { code?: string })?.code === "ERR_CANCELED") {
+          return
+        }
+
+        const message = axios.isAxiosError(err)
+          ? err.response?.data?.message ?? err.message ?? "No se pudieron cargar las cuotas"
+          : (err as Error).message ?? "No se pudieron cargar las cuotas"
+
+        setErrors((prev) => ({ ...prev, cuotas: message }))
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoadingStates((prev) => ({ ...prev, cuotas: false }))
+        }
+      }
+    }
+
+    loadCuotas()
+
+    return () => {
+      controller.abort()
+    }
+  }, [filtersByTab.cuotas])
+
+  const handleFiltersChange = (tab: TabKey, updates: Partial<ReportFilters>) => {
+    setFormFiltersByTab((prev) => ({
+      ...prev,
+      [tab]: { ...prev[tab], ...updates },
+    }))
+  }
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    setFilters(formFilters)
+
+    setFiltersByTab((prev) => ({
+      ...prev,
+      [activeTab]: { ...formFiltersByTab[activeTab] },
+    }))
   }
 
   const handleReset = () => {
-    setFormFilters(DEFAULT_FILTERS)
-    setFilters(DEFAULT_FILTERS)
+    const defaults = createDefaultFilters()
+
+    setFormFiltersByTab((prev) => ({
+      ...prev,
+      [activeTab]: defaults,
+    }))
+
+    setFiltersByTab((prev) => ({
+      ...prev,
+      [activeTab]: defaults,
+    }))
   }
 
-  const kardexTotals = useMemo(() => {
-    if (!dashboardSummary) {
-      return null
+  const getTotalItems = (key: PaginationKey) => {
+    switch (key) {
+      case "kardex":
+        return kardexRows.length
+      case "reconciliaciones":
+        return reconciliationRows.length
+      case "cuotasEstudiantes":
+        return cuotasDashboard?.estudiantes?.length ?? 0
+      case "cuotas":
+      default:
+        return cuotasRows.length
+    }
+  }
+
+  const handlePageChange = (key: PaginationKey, nextPage: number) => {
+    setPagination((prev) => {
+      const { pageSize } = prev[key]
+      const totalItems = getTotalItems(key)
+      const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
+      const page = Math.min(Math.max(1, nextPage), totalPages)
+
+      if (page === prev[key].page) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        [key]: { ...prev[key], page },
+      }
+    })
+  }
+
+  const handlePageSizeChange = (key: PaginationKey, size: number) => {
+    setPagination((prev) => ({
+      ...prev,
+      [key]: { page: 1, pageSize: size },
+    }))
+  }
+
+  const getPaginationLoading = (key: PaginationKey) => {
+    if (key === "kardex") {
+      return loadingStates.kardex
     }
 
-    return dashboardSummary.kardex
-  }, [dashboardSummary])
-
-  const reconciliacionTotals = useMemo(() => {
-    if (!dashboardSummary) {
-      return null
+    if (key === "reconciliaciones") {
+      return loadingStates.reconciliaciones
     }
 
-    return dashboardSummary.reconciliaciones
-  }, [dashboardSummary])
+    return loadingStates.cuotas
+  }
 
-  const cuotasTotals = useMemo(() => {
-    if (!dashboardSummary) {
-      return null
-    }
+  const handleRowAction = (
+    tab: "kardex" | "reconciliaciones",
+    action: RowAction,
+    reference?: string,
+  ) => {
+    const tabLabel = TAB_LABELS[tab]
+    const actionLabel = ACTION_LABELS[action]
 
-    return dashboardSummary.cuotas
-  }, [dashboardSummary])
+    toast({
+      title: `${actionLabel} (${tabLabel})`,
+      description:
+        reference && reference.trim().length > 0
+          ? `Acción pendiente de implementación para ${reference}.`
+          : "Acción pendiente de implementación.",
+    })
+  }
 
   const estudiantesResumen = useMemo(() => cuotasDashboard?.summary ?? null, [cuotasDashboard])
+  const estudiantes = useMemo(() => cuotasDashboard?.estudiantes ?? [], [cuotasDashboard])
 
-  const renderTablePlaceholder = (message: string, columns = 7) => (
+  const renderTablePlaceholder = (message: string, columns = 7, isLoading = false) => (
     <TableRow>
       <TableCell colSpan={columns} className="py-8 text-center text-sm text-muted-foreground">
-        {loading ? "Cargando información..." : message}
+        {isLoading ? "Cargando información..." : message}
       </TableCell>
     </TableRow>
   )
+
+  const renderPaginationControls = (key: PaginationKey, totalItems: number) => {
+    if (totalItems === 0) {
+      return null
+    }
+
+    const { page, pageSize } = pagination[key]
+    const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
+    const safePage = Math.min(page, totalPages)
+    const start = (safePage - 1) * pageSize + 1
+    const end = Math.min(totalItems, safePage * pageSize)
+    const isLoading = getPaginationLoading(key)
+
+    return (
+      <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-muted-foreground">
+          Mostrando {start}-{end} de {totalItems} registros
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Por página:</span>
+            <Select
+              value={String(pageSize)}
+              onValueChange={(value) => handlePageSizeChange(key, Number(value))}
+              disabled={isLoading}
+            >
+              <SelectTrigger className="w-[120px]">
+                <SelectValue placeholder="Elementos" />
+              </SelectTrigger>
+              <SelectContent>
+                {PAGE_SIZE_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={String(option)}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={safePage <= 1 || isLoading}
+              onClick={() => handlePageChange(key, safePage - 1)}
+            >
+              Anterior
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Página {safePage} de {totalPages}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={safePage >= totalPages || isLoading}
+              onClick={() => handlePageChange(key, safePage + 1)}
+            >
+              Siguiente
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const paginatedKardexRows = useMemo(() => {
+    const { page, pageSize } = pagination.kardex
+    const start = (page - 1) * pageSize
+    return kardexRows.slice(start, start + pageSize)
+  }, [kardexRows, pagination.kardex])
+
+  const paginatedReconciliationRows = useMemo(() => {
+    const { page, pageSize } = pagination.reconciliaciones
+    const start = (page - 1) * pageSize
+    return reconciliationRows.slice(start, start + pageSize)
+  }, [reconciliationRows, pagination.reconciliaciones])
+
+  const paginatedCuotasRows = useMemo(() => {
+    const { page, pageSize } = pagination.cuotas
+    const start = (page - 1) * pageSize
+    return cuotasRows.slice(start, start + pageSize)
+  }, [cuotasRows, pagination.cuotas])
+
+  const paginatedCuotasEstudiantes = useMemo(() => {
+    const { page, pageSize } = pagination.cuotasEstudiantes
+    const start = (page - 1) * pageSize
+    return estudiantes.slice(start, start + pageSize)
+  }, [estudiantes, pagination.cuotasEstudiantes])
+
+  useEffect(() => {
+    setPagination((prev) => {
+      const { page, pageSize } = prev.kardex
+      const totalPages = Math.max(1, Math.ceil(kardexRows.length / pageSize))
+      if (page <= totalPages) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        kardex: { ...prev.kardex, page: totalPages },
+      }
+    })
+  }, [kardexRows])
+
+  useEffect(() => {
+    setPagination((prev) => {
+      const { page, pageSize } = prev.reconciliaciones
+      const totalPages = Math.max(1, Math.ceil(reconciliationRows.length / pageSize))
+      if (page <= totalPages) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        reconciliaciones: { ...prev.reconciliaciones, page: totalPages },
+      }
+    })
+  }, [reconciliationRows])
+
+  useEffect(() => {
+    setPagination((prev) => {
+      const { page, pageSize } = prev.cuotas
+      const totalPages = Math.max(1, Math.ceil(cuotasRows.length / pageSize))
+      if (page <= totalPages) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        cuotas: { ...prev.cuotas, page: totalPages },
+      }
+    })
+  }, [cuotasRows])
+
+  useEffect(() => {
+    setPagination((prev) => {
+      const { page, pageSize } = prev.cuotasEstudiantes
+      const totalPages = Math.max(1, Math.ceil(estudiantes.length / pageSize))
+      if (page <= totalPages) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        cuotasEstudiantes: { ...prev.cuotasEstudiantes, page: totalPages },
+      }
+    })
+  }, [estudiantes])
+
+  const activeFormFilters = formFiltersByTab[activeTab]
+  const activeLoading = loadingStates[activeTab]
+  const activeError = errors[activeTab]
 
   return (
     <div className="space-y-6">
@@ -258,58 +646,76 @@ export const ReportesFinancieros = () => {
             <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
               <div className="flex flex-1 flex-wrap gap-3">
                 <Input
-                  value={formFilters.search}
-                  onChange={(event) => setFormFilters((prev) => ({ ...prev, search: event.target.value }))}
+                  value={activeFormFilters.search}
+                  onChange={(event) =>
+                    handleFiltersChange(activeTab, { search: event.target.value })
+                  }
                   placeholder="Buscar por estudiante, carnet, programa o referencia"
                   className="w-full min-w-[220px] flex-1"
                 />
+                {activeTab === "kardex" ? (
+                  <Select
+                    value={activeFormFilters.estadoPago}
+                    onValueChange={(value) =>
+                      handleFiltersChange("kardex", { estadoPago: value })
+                    }
+                  >
+                    <SelectTrigger className="w-full min-w-[160px] sm:w-[180px]">
+                      <SelectValue placeholder="Estado de pago" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="todos">Todos los pagos</SelectItem>
+                      <SelectItem value="aprobado">Aprobado</SelectItem>
+                      <SelectItem value="pendiente_revision">Pendiente</SelectItem>
+                      <SelectItem value="rechazado">Rechazado</SelectItem>
+                    </SelectContent>
+                  </Select>
+                ) : null}
+                {activeTab !== "cuotas" ? (
+                  <Select
+                    value={activeFormFilters.estadoReconciliacion}
+                    onValueChange={(value) =>
+                      handleFiltersChange(activeTab, {
+                        estadoReconciliacion: value,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="w-full min-w-[160px] sm:w-[180px]">
+                      <SelectValue placeholder="Estado conciliación" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="todos">Todas las conciliaciones</SelectItem>
+                      <SelectItem value="conciliado">Conciliado</SelectItem>
+                      <SelectItem value="pendiente">Pendiente</SelectItem>
+                      <SelectItem value="rechazado">Rechazado</SelectItem>
+                      <SelectItem value="sin_coincidencia">Sin coincidencia</SelectItem>
+                    </SelectContent>
+                  </Select>
+                ) : null}
+                {activeTab === "cuotas" ? (
+                  <Select
+                    value={activeFormFilters.estadoCuota}
+                    onValueChange={(value) =>
+                      handleFiltersChange("cuotas", { estadoCuota: value })
+                    }
+                  >
+                    <SelectTrigger className="w-full min-w-[160px] sm:w-[180px]">
+                      <SelectValue placeholder="Estado de cuota" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="todos">Todas las cuotas</SelectItem>
+                      <SelectItem value="pendiente">Pendiente</SelectItem>
+                      <SelectItem value="pagado">Pagado</SelectItem>
+                      <SelectItem value="parcial">Pago parcial</SelectItem>
+                      <SelectItem value="vencido">Vencido</SelectItem>
+                    </SelectContent>
+                  </Select>
+                ) : null}
                 <Select
-                  value={formFilters.estadoPago}
-                  onValueChange={(value) => setFormFilters((prev) => ({ ...prev, estadoPago: value }))}
-                >
-                  <SelectTrigger className="w-full min-w-[160px] sm:w-[180px]">
-                    <SelectValue placeholder="Estado de pago" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="todos">Todos los pagos</SelectItem>
-                    <SelectItem value="aprobado">Aprobado</SelectItem>
-                    <SelectItem value="pendiente_revision">Pendiente</SelectItem>
-                    <SelectItem value="rechazado">Rechazado</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={formFilters.estadoReconciliacion}
-                  onValueChange={(value) => setFormFilters((prev) => ({ ...prev, estadoReconciliacion: value }))}
-                >
-                  <SelectTrigger className="w-full min-w-[160px] sm:w-[180px]">
-                    <SelectValue placeholder="Estado conciliación" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="todos">Todas las conciliaciones</SelectItem>
-                    <SelectItem value="conciliado">Conciliado</SelectItem>
-                    <SelectItem value="pendiente">Pendiente</SelectItem>
-                    <SelectItem value="rechazado">Rechazado</SelectItem>
-                    <SelectItem value="sin_coincidencia">Sin coincidencia</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={formFilters.estadoCuota}
-                  onValueChange={(value) => setFormFilters((prev) => ({ ...prev, estadoCuota: value }))}
-                >
-                  <SelectTrigger className="w-full min-w-[160px] sm:w-[180px]">
-                    <SelectValue placeholder="Estado de cuota" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="todos">Todas las cuotas</SelectItem>
-                    <SelectItem value="pendiente">Pendiente</SelectItem>
-                    <SelectItem value="pagado">Pagado</SelectItem>
-                    <SelectItem value="parcial">Pago parcial</SelectItem>
-                    <SelectItem value="vencido">Vencido</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={String(formFilters.limit)}
-                  onValueChange={(value) => setFormFilters((prev) => ({ ...prev, limit: Number(value) }))}
+                  value={String(activeFormFilters.limit)}
+                  onValueChange={(value) =>
+                    handleFiltersChange(activeTab, { limit: Number(value) })
+                  }
                 >
                   <SelectTrigger className="w-full min-w-[120px] sm:w-[140px]">
                     <SelectValue placeholder="Límite" />
@@ -324,11 +730,11 @@ export const ReportesFinancieros = () => {
                 </Select>
               </div>
               <div className="flex gap-2">
-                <Button type="button" variant="outline" onClick={handleReset} disabled={loading}>
+                <Button type="button" variant="outline" onClick={handleReset} disabled={activeLoading}>
                   Restablecer
                 </Button>
-                <Button type="submit" disabled={loading}>
-                  {loading ? (
+                <Button type="submit" disabled={activeLoading}>
+                  {activeLoading ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   ) : (
                     <RefreshCw className="mr-2 h-4 w-4" />
@@ -341,10 +747,10 @@ export const ReportesFinancieros = () => {
         </CardContent>
       </Card>
 
-      {error ? (
+      {activeError ? (
         <Alert variant="destructive">
           <AlertTitle>Ocurrió un problema</AlertTitle>
-          <AlertDescription>{error}</AlertDescription>
+          <AlertDescription>{activeError}</AlertDescription>
         </Alert>
       ) : null}
 
@@ -441,7 +847,7 @@ export const ReportesFinancieros = () => {
         </Card>
       </div>
 
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabKey)}>
         <TabsList className="w-full overflow-x-auto">
           <TabsTrigger value="kardex" className="flex-1">Kardex</TabsTrigger>
           <TabsTrigger value="reconciliaciones" className="flex-1">Conciliaciones</TabsTrigger>
@@ -453,7 +859,7 @@ export const ReportesFinancieros = () => {
             <CardHeader>
               <CardTitle>Movimientos del kardex</CardTitle>
               <CardDescription>
-                Actualizado {lastUpdated ? formatDateTime(lastUpdated) : "sin información"}
+                Actualizado {kardexLastUpdated ? formatDateTime(kardexLastUpdated) : "sin información"}
               </CardDescription>
             </CardHeader>
             <CardContent className="overflow-x-auto">
@@ -467,16 +873,24 @@ export const ReportesFinancieros = () => {
                     <TableHead>Estado</TableHead>
                     <TableHead>Método</TableHead>
                     <TableHead>Conciliaciones</TableHead>
+                    <TableHead className="w-[140px] text-center">Acciones</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {kardexRows.length === 0 ? (
-                    renderTablePlaceholder("No se encontraron movimientos para los filtros seleccionados")
+                    renderTablePlaceholder(
+                      "No se encontraron movimientos para los filtros seleccionados",
+                      8,
+                      loadingStates.kardex,
+                    )
                   ) : (
-                    kardexRows.map((row) => {
+                    paginatedKardexRows.map((row) => {
                       const estado = row.estado_pago ?? ""
                       const estadoClase = estadoPagoClasses[estado] ?? "bg-slate-500/15 text-slate-700 border-slate-500/30"
                       const estadoLabel = estadoPagoLabels[estado] ?? (estado ? estado.replace(/_/g, " ") : "Sin estado")
+                      const referenceLabel = row.numero_boleta
+                        ? `Boleta ${row.numero_boleta}`
+                        : `Pago #${row.id}`
 
                       return (
                         <TableRow key={row.id}>
@@ -522,12 +936,44 @@ export const ReportesFinancieros = () => {
                               <span className="text-xs text-muted-foreground">Sin conciliaciones</span>
                             )}
                           </TableCell>
+                          <TableCell>
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRowAction("kardex", "view", referenceLabel)}
+                                aria-label="Ver detalle"
+                              >
+                                <Eye className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRowAction("kardex", "edit", referenceLabel)}
+                                aria-label="Editar"
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRowAction("kardex", "delete", referenceLabel)}
+                                aria-label="Eliminar"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </TableCell>
                         </TableRow>
                       )
                     })
                   )}
                 </TableBody>
               </Table>
+              {renderPaginationControls("kardex", kardexRows.length)}
             </CardContent>
           </Card>
         </TabsContent>
@@ -537,7 +983,11 @@ export const ReportesFinancieros = () => {
             <CardHeader>
               <CardTitle>Conciliaciones bancarias</CardTitle>
               <CardDescription>
-                Resultado de los registros importados desde las entidades financieras
+                Resultado de los registros importados desde las entidades financieras. Actualizado
+                {" "}
+                {reconciliacionesLastUpdated
+                  ? formatDateTime(reconciliacionesLastUpdated)
+                  : "sin información"}
               </CardDescription>
             </CardHeader>
             <CardContent className="overflow-x-auto">
@@ -550,19 +1000,22 @@ export const ReportesFinancieros = () => {
                     <TableHead>Estado</TableHead>
                     <TableHead>Prospecto</TableHead>
                     <TableHead>Kardex vinculado</TableHead>
+                    <TableHead className="w-[140px] text-center">Acciones</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {reconciliationRows.length === 0 ? (
                     renderTablePlaceholder(
                       "No se encontraron conciliaciones para los filtros seleccionados",
-                      6,
+                      7,
+                      loadingStates.reconciliaciones,
                     )
                   ) : (
-                    reconciliationRows.map((row) => {
+                    paginatedReconciliationRows.map((row) => {
                       const estado = row.status ?? ""
                       const estadoClase = conciliacionClasses[estado] ?? "bg-slate-500/15 text-slate-700 border-slate-500/30"
                       const estadoLabel = conciliacionLabels[estado] ?? (estado ? estado.replace(/_/g, " ") : "Sin estado")
+                      const reference = row.reference ?? `Conciliación #${row.id}`
 
                       return (
                         <TableRow key={row.id}>
@@ -592,12 +1045,44 @@ export const ReportesFinancieros = () => {
                               <span className="text-xs text-muted-foreground">Sin vincular</span>
                             )}
                           </TableCell>
+                          <TableCell>
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRowAction("reconciliaciones", "view", reference)}
+                                aria-label="Ver detalle"
+                              >
+                                <Eye className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRowAction("reconciliaciones", "edit", reference)}
+                                aria-label="Editar"
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRowAction("reconciliaciones", "delete", reference)}
+                                aria-label="Eliminar"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </TableCell>
                         </TableRow>
                       )
                     })
                   )}
                 </TableBody>
               </Table>
+              {renderPaginationControls("reconciliaciones", reconciliationRows.length)}
             </CardContent>
           </Card>
         </TabsContent>
@@ -606,7 +1091,13 @@ export const ReportesFinancieros = () => {
           <Card>
             <CardHeader>
               <CardTitle>Seguimiento por estudiante</CardTitle>
-              <CardDescription>Resumen de cuotas pendientes y próximas fechas de pago</CardDescription>
+              <CardDescription>
+                Resumen de cuotas pendientes y próximas fechas de pago. Actualizado
+                {" "}
+                {cuotasDashboard?.timestamp
+                  ? formatDateTime(cuotasDashboard.timestamp)
+                  : "sin información"}
+              </CardDescription>
             </CardHeader>
             <CardContent className="overflow-x-auto">
               <Table>
@@ -621,13 +1112,14 @@ export const ReportesFinancieros = () => {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {!cuotasDashboard || cuotasDashboard.estudiantes.length === 0 ? (
+                  {estudiantes.length === 0 ? (
                     renderTablePlaceholder(
                       "No se encontraron estudiantes con cuotas para los filtros seleccionados",
                       6,
+                      loadingStates.cuotas,
                     )
                   ) : (
-                    cuotasDashboard.estudiantes.map(
+                    paginatedCuotasEstudiantes.map(
                       (estudiante: CuotasDashboardEstudiante, index) => (
                         <TableRow
                           key={
@@ -636,40 +1128,46 @@ export const ReportesFinancieros = () => {
                             `est-${index}`
                           }
                         >
-                        <TableCell className="min-w-[220px]">
-                          <div className="font-medium">{estudiante.prospecto?.nombre ?? "Sin nombre"}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {estudiante.prospecto?.carnet ?? "-"}
-                            {estudiante.prospecto?.telefono ? ` · ${estudiante.prospecto.telefono}` : ""}
-                          </div>
-                        </TableCell>
-                        <TableCell className="min-w-[160px]">{estudiante.programa?.nombre ?? "-"}</TableCell>
-                        <TableCell>{formatCurrency(estudiante.saldo_pendiente)}</TableCell>
-                        <TableCell>{estudiante.cuotas_pendientes}</TableCell>
-                        <TableCell>{estudiante.cuotas_pagadas}</TableCell>
-                        <TableCell>
-                          {estudiante.proxima_cuota ? (
-                            <div className="text-xs">
-                              <div className="font-medium">Cuota #{estudiante.proxima_cuota.numero_cuota}</div>
-                              <div>{formatDate(estudiante.proxima_cuota.fecha_vencimiento)}</div>
-                              <div className="text-muted-foreground">{formatCurrency(estudiante.proxima_cuota.monto)}</div>
+                          <TableCell className="min-w-[220px]">
+                            <div className="font-medium">{estudiante.prospecto?.nombre ?? "Sin nombre"}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {estudiante.prospecto?.carnet ?? "-"}
+                              {estudiante.prospecto?.telefono ? ` · ${estudiante.prospecto.telefono}` : ""}
                             </div>
-                          ) : (
-                            <span className="text-xs text-muted-foreground">Sin próximas cuotas</span>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))
+                          </TableCell>
+                          <TableCell className="min-w-[160px]">{estudiante.programa?.nombre ?? "-"}</TableCell>
+                          <TableCell>{formatCurrency(estudiante.saldo_pendiente)}</TableCell>
+                          <TableCell>{estudiante.cuotas_pendientes}</TableCell>
+                          <TableCell>{estudiante.cuotas_pagadas}</TableCell>
+                          <TableCell>
+                            {estudiante.proxima_cuota ? (
+                              <div className="text-xs">
+                                <div className="font-medium">Cuota #{estudiante.proxima_cuota.numero_cuota}</div>
+                                <div>{formatDate(estudiante.proxima_cuota.fecha_vencimiento)}</div>
+                                <div className="text-muted-foreground">{formatCurrency(estudiante.proxima_cuota.monto)}</div>
+                              </div>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">Sin próximas cuotas</span>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ),
+                    )
                   )}
                 </TableBody>
               </Table>
+              {renderPaginationControls("cuotasEstudiantes", estudiantes.length)}
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
               <CardTitle>Cuotas registradas</CardTitle>
-              <CardDescription>Detalle de cuotas individuales de estudiantes</CardDescription>
+              <CardDescription>
+                Detalle de cuotas individuales de estudiantes. Actualizado
+                {" "}
+                {cuotasLastUpdated ? formatDateTime(cuotasLastUpdated) : "sin información"}
+              </CardDescription>
             </CardHeader>
             <CardContent className="overflow-x-auto">
               <Table>
@@ -688,9 +1186,10 @@ export const ReportesFinancieros = () => {
                     renderTablePlaceholder(
                       "No se encontraron cuotas para los filtros seleccionados",
                       6,
+                      loadingStates.cuotas,
                     )
                   ) : (
-                    cuotasRows.map((row) => {
+                    paginatedCuotasRows.map((row) => {
                       const estado = row.estado ?? ""
                       const estadoClase = cuotaEstadoClasses[estado] ?? "bg-slate-500/15 text-slate-700 border-slate-500/30"
                       const estadoLabel = cuotaEstadoLabels[estado] ?? (estado ? estado.replace(/_/g, " ") : "Sin estado")
@@ -728,6 +1227,7 @@ export const ReportesFinancieros = () => {
                   )}
                 </TableBody>
               </Table>
+              {renderPaginationControls("cuotas", cuotasRows.length)}
             </CardContent>
           </Card>
         </TabsContent>


### PR DESCRIPTION
## Summary
- introduce per-tab filter state, loading, and error management for kardex, reconciliation, and cuotas data
- add reusable pagination helpers and controls to each financial report table
- surface action buttons in kardex and reconciliation rows with placeholder toasts for pending functionality

## Testing
- npm run lint *(terminated due to Next.js lint plugin warnings stalling execution)*

------
https://chatgpt.com/codex/tasks/task_e_68f99a99af3483288ecc5acac08a0d62