### PR TITLE
Implement cuotas dashboard tab

### DIFF
--- a/components/finanzas/CuotasDashboardTab.tsx
+++ b/components/finanzas/CuotasDashboardTab.tsx
@@ -1,0 +1,391 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { RefreshCw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import {
+  getCuotasDashboard,
+  getKardexDashboard,
+  type CuotasDashboardEstudiante,
+  type CuotasDashboardMetrics,
+  type CuotasDashboardResumen,
+  type MantenimientosFilters,
+} from "@/services/mantenimientos"
+
+const currencyFormatter = new Intl.NumberFormat("es-GT", {
+  style: "currency",
+  currency: "GTQ",
+})
+
+const formatCurrency = (value: number | null | undefined) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return currencyFormatter.format(0)
+  }
+
+  return currencyFormatter.format(value)
+}
+
+const formatDate = (value: string | null | undefined) => {
+  if (!value) {
+    return "-"
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+
+  return parsed.toLocaleDateString("es-GT")
+}
+
+const formatDateTime = (value: string | null | undefined) => {
+  if (!value) {
+    return "sin información"
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+
+  return parsed.toLocaleString("es-GT")
+}
+
+const PAGE_SIZE_OPTIONS = [
+  { label: "10", value: 10 },
+  { label: "25", value: 25 },
+  { label: "50", value: 50 },
+  { label: "100", value: 100 },
+  { label: "Todos", value: "all" as const },
+]
+
+type PageSizeValue = number | "all"
+
+interface CuotasDashboardTabProps {
+  filters?: MantenimientosFilters
+  onLoadingChange?: (loading: boolean) => void
+  onError?: (error: string | null) => void
+  onMetricsChange?: (metrics: CuotasDashboardMetrics | null) => void
+  onSummaryChange?: (summary: CuotasDashboardResumen | null, timestamp: string | null) => void
+}
+
+export const CuotasDashboardTab = ({
+  filters,
+  onLoadingChange,
+  onError,
+  onMetricsChange,
+  onSummaryChange,
+}: CuotasDashboardTabProps) => {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [summary, setSummary] = useState<CuotasDashboardResumen | null>(null)
+  const [timestamp, setTimestamp] = useState<string | null>(null)
+  const [estudiantes, setEstudiantes] = useState<CuotasDashboardEstudiante[]>([])
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState<PageSizeValue>(10)
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  const totalItems = estudiantes.length
+
+  const paginatedEstudiantes = useMemo(() => {
+    if (pageSize === "all") {
+      return estudiantes
+    }
+
+    const start = (page - 1) * pageSize
+    return estudiantes.slice(start, start + pageSize)
+  }, [estudiantes, page, pageSize])
+
+  const totalPages = useMemo(() => {
+    if (pageSize === "all") {
+      return 1
+    }
+
+    return Math.max(1, Math.ceil(totalItems / pageSize))
+  }, [pageSize, totalItems])
+
+  const handlePageChange = useCallback(
+    (nextPage: number) => {
+      const safePage = Math.min(Math.max(1, nextPage), totalPages)
+      if (safePage !== page) {
+        setPage(safePage)
+      }
+    },
+    [page, totalPages],
+  )
+
+  const handlePageSizeChange = useCallback((value: string) => {
+    const parsed = Number(value)
+    setPage(1)
+    setPageSize(Number.isNaN(parsed) ? "all" : parsed)
+  }, [])
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [page, totalPages])
+
+  useEffect(() => {
+    if (!summary) {
+      return
+    }
+
+    console.info("[Reportes financieros] Resumen de cuotas", summary)
+  }, [summary])
+
+  const fetchCuotas = useCallback(async () => {
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    setLoading(true)
+    onLoadingChange?.(true)
+    setError(null)
+    onError?.(null)
+
+    try {
+      const [dashboardResponse, cuotasDashboardResponse] = await Promise.all([
+        getKardexDashboard(filters, { signal: controller.signal }),
+        getCuotasDashboard(filters, { signal: controller.signal }),
+      ])
+
+      if (controller.signal.aborted) {
+        return
+      }
+
+      const cuotasSummary = cuotasDashboardResponse.summary ?? null
+      const cuotasTimestamp = cuotasDashboardResponse.timestamp ?? null
+      const estudiantesResponse = cuotasDashboardResponse.estudiantes ?? []
+      const metrics = dashboardResponse.cuotas ?? null
+
+      setSummary(cuotasSummary)
+      setTimestamp(cuotasTimestamp)
+      setEstudiantes(estudiantesResponse)
+      setPage(1)
+      onSummaryChange?.(cuotasSummary, cuotasTimestamp)
+      onMetricsChange?.(metrics)
+    } catch (err) {
+      if ((err as { code?: string })?.code === "ERR_CANCELED") {
+        return
+      }
+
+      console.error("Error al cargar las cuotas", err)
+      setSummary(null)
+      setTimestamp(null)
+      setEstudiantes([])
+      setError("Error al cargar las cuotas.")
+      onSummaryChange?.(null, null)
+      onMetricsChange?.(null)
+      onError?.("Error al cargar las cuotas.")
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false)
+        onLoadingChange?.(false)
+      }
+    }
+  }, [filters, onError, onLoadingChange, onMetricsChange, onSummaryChange])
+
+  useEffect(() => {
+    fetchCuotas()
+
+    return () => {
+      abortControllerRef.current?.abort()
+    }
+  }, [fetchCuotas])
+
+  const handleRetry = () => {
+    fetchCuotas()
+  }
+
+  const renderPlaceholder = (message: string) => (
+    <TableRow>
+      <TableCell colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+        {message}
+      </TableCell>
+    </TableRow>
+  )
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Error al cargar las cuotas</CardTitle>
+            <CardDescription>Ocurrió un problema al obtener la información de cuotas.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Puedes intentar nuevamente para recargar la información.
+            </p>
+            <Button type="button" onClick={handleRetry} variant="outline">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Reintentar
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Estudiantes activos</CardTitle>
+            <CardDescription className="text-xs">Con planes de pago registrados</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{summary?.estudiantes_activos ?? 0}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Saldo estimado</CardTitle>
+            <CardDescription className="text-xs">Monto pendiente proyectado</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{formatCurrency(summary?.saldo_estimado)}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Estudiantes en mora</CardTitle>
+            <CardDescription className="text-xs">Con cuotas vencidas</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{summary?.en_mora ?? 0}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Planes reestructurados</CardTitle>
+            <CardDescription className="text-xs">Acuerdos activos con ajustes</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{summary?.planes_reestructurados ?? 0}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Seguimiento por estudiante</CardTitle>
+          <CardDescription>
+            Resumen de cuotas pendientes y próximas fechas de pago. Actualizado {formatDateTime(timestamp)}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Estudiante</TableHead>
+                <TableHead>Programa</TableHead>
+                <TableHead>Saldo pendiente</TableHead>
+                <TableHead>Cuotas pendientes</TableHead>
+                <TableHead>Cuotas pagadas</TableHead>
+                <TableHead>Próxima cuota</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {totalItems === 0 ? (
+                loading
+                  ? renderPlaceholder("Cargando datos de cuotas…")
+                  : renderPlaceholder(
+                      "No se encontraron estudiantes con cuotas para los filtros seleccionados.",
+                    )
+              ) : (
+                paginatedEstudiantes.map((estudiante, index) => (
+                  <TableRow
+                    key={
+                      estudiante.estudiante_programa_id ?? estudiante.prospecto?.id ?? `cuota-${index}`
+                    }
+                  >
+                    <TableCell className="min-w-[220px]">
+                      <div className="font-medium">{estudiante.prospecto?.nombre ?? "Sin nombre"}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {estudiante.prospecto?.carnet ?? "-"}
+                        {estudiante.prospecto?.telefono ? ` · ${estudiante.prospecto.telefono}` : ""}
+                      </div>
+                    </TableCell>
+                    <TableCell className="min-w-[160px]">{estudiante.programa?.nombre ?? "-"}</TableCell>
+                    <TableCell>{formatCurrency(estudiante.saldo_pendiente)}</TableCell>
+                    <TableCell>{estudiante.cuotas_pendientes}</TableCell>
+                    <TableCell>{estudiante.cuotas_pagadas}</TableCell>
+                    <TableCell>
+                      {estudiante.proxima_cuota ? (
+                        <div className="text-xs">
+                          <div className="font-medium">Cuota #{estudiante.proxima_cuota.numero_cuota}</div>
+                          <div>{formatDate(estudiante.proxima_cuota.fecha_vencimiento)}</div>
+                          <div className="text-muted-foreground">
+                            {formatCurrency(estudiante.proxima_cuota.monto)}
+                          </div>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Sin próximas cuotas</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+          {totalItems > 0 ? (
+            <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-muted-foreground">
+                {pageSize === "all"
+                  ? `Mostrando ${totalItems} de ${totalItems} registros`
+                  : `Mostrando ${(page - 1) * (pageSize as number) + 1}-${
+                      Math.min(totalItems, page * (pageSize as number))
+                    } de ${totalItems} registros`}
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">Por página:</span>
+                  <Select value={String(pageSize)} onValueChange={handlePageSizeChange} disabled={loading}>
+                    <SelectTrigger className="w-[120px]">
+                      <SelectValue placeholder="Elementos" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PAGE_SIZE_OPTIONS.map((option) => (
+                        <SelectItem key={String(option.value)} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {pageSize === "all" ? null : (
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1 || loading}
+                      onClick={() => handlePageChange(page - 1)}
+                    >
+                      Anterior
+                    </Button>
+                    <span className="text-sm text-muted-foreground">Página {page} de {totalPages}</span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages || loading}
+                      onClick={() => handlePageChange(page + 1)}
+                    >
+                      Siguiente
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default CuotasDashboardTab

--- a/components/finanzas/reportes-financieros.tsx
+++ b/components/finanzas/reportes-financieros.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import axios from "axios"
 import {
   Card,
@@ -39,18 +39,16 @@ import { Label } from "@/components/ui/label"
 import { Eye, Loader2, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
-  getCuotasDashboard,
   getKardexDashboard,
   getKardexData,
-  type CuotaProgramaResumen,
-  type CuotasDashboardEstudiante,
-  type CuotasDashboardResponse,
   type CuotasDashboardMetrics,
+  type CuotasDashboardResumen,
   type KardexDashboardMetrics,
   type KardexPagoResumen,
   type ReconciliationDashboardMetrics,
   type ReconciliationRecordResumen,
 } from "@/services/mantenimientos"
+import { CuotasDashboardTab } from "./CuotasDashboardTab"
 
 const currencyFormatter = new Intl.NumberFormat("es-GT", {
   style: "currency",
@@ -119,20 +117,6 @@ const conciliacionClasses: Record<string, string> = {
   imported: "bg-slate-500/15 text-slate-700 border-slate-500/30",
 }
 
-const cuotaEstadoLabels: Record<string, string> = {
-  pagado: "Pagado",
-  pendiente: "Pendiente",
-  parcial: "Pago parcial",
-  vencido: "Vencido",
-}
-
-const cuotaEstadoClasses: Record<string, string> = {
-  pagado: "bg-emerald-500/15 text-emerald-700 border-emerald-500/30",
-  pendiente: "bg-amber-500/15 text-amber-700 border-amber-500/30",
-  parcial: "bg-sky-500/15 text-sky-700 border-sky-500/30",
-  vencido: "bg-red-500/15 text-red-600 border-red-500/30",
-}
-
 type LimitValue = number | "all"
 
 interface ReportFilters {
@@ -152,7 +136,7 @@ const BASE_FILTERS: ReportFilters = {
 }
 
 type TabKey = "kardex" | "reconciliaciones" | "cuotas"
-type PaginationKey = "kardex" | "reconciliaciones" | "cuotasEstudiantes" | "cuotas"
+type PaginationKey = "kardex" | "reconciliaciones"
 
 type PageSizeValue = number | "all"
 
@@ -290,19 +274,15 @@ export const ReportesFinancieros = () => {
   const [reconciliacionTotals, setReconciliacionTotals] =
     useState<ReconciliationDashboardMetrics | null>(null)
   const [cuotasTotals, setCuotasTotals] = useState<CuotasDashboardMetrics | null>(null)
+  const [cuotasSummary, setCuotasSummary] = useState<CuotasDashboardResumen | null>(null)
   const [kardexRows, setKardexRows] = useState<KardexPagoResumen[]>([])
   const [reconciliationRows, setReconciliationRows] = useState<ReconciliationRecordResumen[]>([])
-  const [cuotasRows, setCuotasRows] = useState<CuotaProgramaResumen[]>([])
-  const [cuotasDashboard, setCuotasDashboard] = useState<CuotasDashboardResponse | null>(null)
   const [kardexLastUpdated, setKardexLastUpdated] = useState<string | null>(null)
   const [reconciliacionesLastUpdated, setReconciliacionesLastUpdated] =
     useState<string | null>(null)
-  const [cuotasLastUpdated, setCuotasLastUpdated] = useState<string | null>(null)
   const [pagination, setPagination] = useState<Record<PaginationKey, PaginationState>>({
     kardex: { page: 1, pageSize: 10 },
     reconciliaciones: { page: 1, pageSize: 10 },
-    cuotasEstudiantes: { page: 1, pageSize: 10 },
-    cuotas: { page: 1, pageSize: 10 },
   })
 
   // Add missing modal and form states
@@ -444,64 +424,6 @@ export const ReportesFinancieros = () => {
     }
   }, [filtersByTab.reconciliaciones])
 
-  useEffect(() => {
-    const controller = new AbortController()
-
-    const loadCuotas = async () => {
-      setLoadingStates((prev) => ({ ...prev, cuotas: true }))
-      setErrors((prev) => ({ ...prev, cuotas: null }))
-
-      const params = buildRequestFilters(filtersByTab.cuotas)
-
-      try {
-        const [dashboardResponse, dataResponse, cuotasDashboardResponse] =
-          await Promise.all([
-            getKardexDashboard(params, { signal: controller.signal }),
-            getKardexData(params, { signal: controller.signal }),
-            getCuotasDashboard(params, { signal: controller.signal }),
-          ])
-
-        if (controller.signal.aborted) {
-          return
-        }
-
-        setCuotasTotals(dashboardResponse.cuotas)
-        setCuotasRows(dataResponse.cuotas)
-        setCuotasLastUpdated(dataResponse.timestamp)
-        setCuotasDashboard(cuotasDashboardResponse)
-        setPagination((prev) => ({
-          ...prev,
-          cuotas:
-            prev.cuotas.page === 1 ? prev.cuotas : { ...prev.cuotas, page: 1 },
-          cuotasEstudiantes:
-            prev.cuotasEstudiantes.page === 1
-              ? prev.cuotasEstudiantes
-              : { ...prev.cuotasEstudiantes, page: 1 },
-        }))
-      } catch (err) {
-        if ((err as { code?: string })?.code === "ERR_CANCELED") {
-          return
-        }
-
-        const message = axios.isAxiosError(err)
-          ? err.response?.data?.message ?? err.message ?? "No se pudieron cargar las cuotas"
-          : (err as Error).message ?? "No se pudieron cargar las cuotas"
-
-        setErrors((prev) => ({ ...prev, cuotas: message }))
-      } finally {
-        if (!controller.signal.aborted) {
-          setLoadingStates((prev) => ({ ...prev, cuotas: false }))
-        }
-      }
-    }
-
-    loadCuotas()
-
-    return () => {
-      controller.abort()
-    }
-  }, [filtersByTab.cuotas])
-
   const handleFiltersChange = (tab: TabKey, updates: Partial<ReportFilters>) => {
     setFormFiltersByTab((prev) => ({
       ...prev,
@@ -537,12 +459,8 @@ export const ReportesFinancieros = () => {
       case "kardex":
         return kardexRows.length
       case "reconciliaciones":
-        return reconciliationRows.length
-      case "cuotasEstudiantes":
-        return cuotasDashboard?.estudiantes?.length ?? 0
-      case "cuotas":
       default:
-        return cuotasRows.length
+        return reconciliationRows.length
     }
   }
 
@@ -583,7 +501,7 @@ export const ReportesFinancieros = () => {
       return loadingStates.reconciliaciones
     }
 
-    return loadingStates.cuotas
+    return loadingStates.reconciliaciones
   }
 
   const handleRowAction = (
@@ -603,8 +521,33 @@ export const ReportesFinancieros = () => {
     })
   }
 
-  const estudiantesResumen = useMemo(() => cuotasDashboard?.summary ?? null, [cuotasDashboard])
-  const estudiantes = useMemo(() => cuotasDashboard?.estudiantes ?? [], [cuotasDashboard])
+  const cuotaFilters = useMemo(
+    () => buildRequestFilters(filtersByTab.cuotas),
+    [filtersByTab.cuotas],
+  )
+  const cuotasResumen = cuotasSummary
+
+  const handleCuotasLoadingChange = useCallback((loading: boolean) => {
+    setLoadingStates((prev) => ({ ...prev, cuotas: loading }))
+  }, [])
+
+  const handleCuotasError = useCallback((message: string | null) => {
+    setErrors((prev) => ({ ...prev, cuotas: message }))
+  }, [])
+
+  const handleCuotasMetricsChange = useCallback(
+    (metrics: CuotasDashboardMetrics | null) => {
+      setCuotasTotals(metrics)
+    },
+    [],
+  )
+
+  const handleCuotasSummaryChange = useCallback(
+    (summary: CuotasDashboardResumen | null, _timestamp: string | null) => {
+      setCuotasSummary(summary)
+    },
+    [],
+  )
 
   const renderTablePlaceholder = (message: string, columns = 7, isLoading = false) => (
     <TableRow>
@@ -696,20 +639,6 @@ export const ReportesFinancieros = () => {
     return reconciliationRows.slice(start, start + pageSize)
   }, [reconciliationRows, pagination.reconciliaciones])
 
-  const paginatedCuotasRows = useMemo(() => {
-    const { page, pageSize } = pagination.cuotas
-    if (pageSize === "all") return cuotasRows
-    const start = (page - 1) * pageSize
-    return cuotasRows.slice(start, start + pageSize)
-  }, [cuotasRows, pagination.cuotas])
-
-  const paginatedCuotasEstudiantes = useMemo(() => {
-    const { page, pageSize } = pagination.cuotasEstudiantes
-    if (pageSize === "all") return estudiantes
-    const start = (page - 1) * pageSize
-    return estudiantes.slice(start, start + pageSize)
-  }, [estudiantes, pagination.cuotasEstudiantes])
-
   useEffect(() => {
     setPagination((prev) => {
       const { page, pageSize } = prev.kardex
@@ -743,39 +672,9 @@ export const ReportesFinancieros = () => {
     })
   }, [reconciliationRows])
 
-  useEffect(() => {
-    setPagination((prev) => {
-      const { page, pageSize } = prev.cuotas
-      const totalPages = Math.max(1, Math.ceil(cuotasRows.length / pageSize))
-      if (page <= totalPages) {
-        return prev
-      }
-
-      return {
-        ...prev,
-        cuotas: { ...prev.cuotas, page: totalPages },
-      }
-    })
-  }, [cuotasRows])
-
-  useEffect(() => {
-    setPagination((prev) => {
-      const { page, pageSize } = prev.cuotasEstudiantes
-      const totalPages = Math.max(1, Math.ceil(estudiantes.length / pageSize))
-      if (page <= totalPages) {
-        return prev
-      }
-
-      return {
-        ...prev,
-        cuotasEstudiantes: { ...prev.cuotasEstudiantes, page: totalPages },
-      }
-    })
-  }, [estudiantes])
-
   const activeFormFilters = formFiltersByTab[activeTab]
   const activeLoading = loadingStates[activeTab]
-  const activeError = errors[activeTab]
+  const activeError = activeTab === "cuotas" ? null : errors[activeTab]
 
   return (
     <div className="space-y-6">
@@ -973,18 +872,18 @@ export const ReportesFinancieros = () => {
             <CardDescription className="text-xs">Con base en planes de pago activos</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2 text-sm">
-            <div className="text-2xl font-semibold">{estudiantesResumen?.estudiantes_activos ?? 0}</div>
+            <div className="text-2xl font-semibold">{cuotasResumen?.estudiantes_activos ?? 0}</div>
             <div className="flex justify-between text-muted-foreground">
               <span>Saldo estimado</span>
-              <span className="font-medium text-foreground">{formatCurrency(estudiantesResumen?.saldo_estimado ?? 0)}</span>
+              <span className="font-medium text-foreground">{formatCurrency(cuotasResumen?.saldo_estimado ?? 0)}</span>
             </div>
             <div className="flex justify-between text-muted-foreground">
               <span>En mora</span>
-              <span className="font-medium text-foreground">{estudiantesResumen?.en_mora ?? 0}</span>
+              <span className="font-medium text-foreground">{cuotasResumen?.en_mora ?? 0}</span>
             </div>
             <div className="flex justify-between text-muted-foreground">
               <span>Planes reestructurados</span>
-              <span className="font-medium text-foreground">{estudiantesResumen?.planes_reestructurados ?? 0}</span>
+              <span className="font-medium text-foreground">{cuotasResumen?.planes_reestructurados ?? 0}</span>
             </div>
           </CardContent>
         </Card>
@@ -1231,148 +1130,13 @@ export const ReportesFinancieros = () => {
         </TabsContent>
 
         <TabsContent value="cuotas" className="space-y-4 pt-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Seguimiento por estudiante</CardTitle>
-              <CardDescription>
-                Resumen de cuotas pendientes y próximas fechas de pago. Actualizado
-                {" "}
-                {cuotasDashboard?.timestamp
-                  ? formatDateTime(cuotasDashboard.timestamp)
-                  : "sin información"}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Estudiante</TableHead>
-                    <TableHead>Programa</TableHead>
-                    <TableHead>Saldo pendiente</TableHead>
-                    <TableHead>Cuotas pendientes</TableHead>
-                    <TableHead>Cuotas pagadas</TableHead>
-                    <TableHead>Próxima cuota</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {estudiantes.length === 0 ? (
-                    renderTablePlaceholder(
-                      "No se encontraron estudiantes con cuotas para los filtros seleccionados",
-                      6,
-                      loadingStates.cuotas,
-                    )
-                  ) : (
-                    paginatedCuotasEstudiantes.map(
-                      (estudiante: CuotasDashboardEstudiante, index) => (
-                        <TableRow
-                          key={
-                            estudiante.estudiante_programa_id ??
-                            estudiante.prospecto?.id ??
-                            `est-${index}`
-                          }
-                        >
-                          <TableCell className="min-w-[220px]">
-                            <div className="font-medium">{estudiante.prospecto?.nombre ?? "Sin nombre"}</div>
-                            <div className="text-xs text-muted-foreground">
-                              {estudiante.prospecto?.carnet ?? "-"}
-                              {estudiante.prospecto?.telefono ? ` · ${estudiante.prospecto.telefono}` : ""}
-                            </div>
-                          </TableCell>
-                          <TableCell className="min-w-[160px]">{estudiante.programa?.nombre ?? "-"}</TableCell>
-                          <TableCell>{formatCurrency(estudiante.saldo_pendiente)}</TableCell>
-                          <TableCell>{estudiante.cuotas_pendientes}</TableCell>
-                          <TableCell>{estudiante.cuotas_pagadas}</TableCell>
-                          <TableCell>
-                            {estudiante.proxima_cuota ? (
-                              <div className="text-xs">
-                                <div className="font-medium">Cuota #{estudiante.proxima_cuota.numero_cuota}</div>
-                                <div>{formatDate(estudiante.proxima_cuota.fecha_vencimiento)}</div>
-                                <div className="text-muted-foreground">{formatCurrency(estudiante.proxima_cuota.monto)}</div>
-                              </div>
-                            ) : (
-                              <span className="text-xs text-muted-foreground">Sin próximas cuotas</span>
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ),
-                    )
-                  )}
-                </TableBody>
-              </Table>
-              {renderPaginationControls("cuotasEstudiantes", estudiantes.length)}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Cuotas registradas</CardTitle>
-              <CardDescription>
-                Detalle de cuotas individuales de estudiantes. Actualizado
-                {" "}
-                {cuotasLastUpdated ? formatDateTime(cuotasLastUpdated) : "sin información"}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Estudiante</TableHead>
-                    <TableHead>Programa</TableHead>
-                    <TableHead>Cuota</TableHead>
-                    <TableHead>Vencimiento</TableHead>
-                    <TableHead>Estado</TableHead>
-                    <TableHead>Pago</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {cuotasRows.length === 0 ? (
-                    renderTablePlaceholder(
-                      "No se encontraron cuotas para los filtros seleccionados",
-                      6,
-                      loadingStates.cuotas,
-                    )
-                  ) : (
-                    paginatedCuotasRows.map((row) => {
-                      const estado = row.estado ?? ""
-                      const estadoClase = cuotaEstadoClasses[estado] ?? "bg-slate-500/15 text-slate-700 border-slate-500/30"
-                      const estadoLabel = cuotaEstadoLabels[estado] ?? (estado ? estado.replace(/_/g, " ") : "Sin estado")
-
-                      return (
-                        <TableRow key={row.id}>
-                          <TableCell className="min-w-[200px]">
-                            <div className="font-medium">{row.prospecto?.nombre ?? "Sin nombre"}</div>
-                            <div className="text-xs text-muted-foreground">{row.prospecto?.carnet ?? "-"}</div>
-                          </TableCell>
-                          <TableCell className="min-w-[160px]">{row.programa?.nombre ?? "-"}</TableCell>
-                          <TableCell>
-                            <div>Cuota #{row.numero_cuota}</div>
-                            <div className="text-xs text-muted-foreground">Monto: {formatCurrency(row.monto)}</div>
-                          </TableCell>
-                          <TableCell>{formatDate(row.fecha_vencimiento)}</TableCell>
-                          <TableCell>
-                            <Badge variant="outline" className={cn("capitalize", estadoClase)}>
-                              {estadoLabel}
-                            </Badge>
-                          </TableCell>
-                          <TableCell>
-                            {row.paid_at ? (
-                              <div className="text-xs">
-                                <div className="font-medium">Pagado</div>
-                                <div>{formatDateTime(row.paid_at)}</div>
-                              </div>
-                            ) : (
-                              <span className="text-xs text-muted-foreground">Sin pago registrado</span>
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      )
-                    })
-                  )}
-                </TableBody>
-              </Table>
-              {renderPaginationControls("cuotas", cuotasRows.length)}
-            </CardContent>
-          </Card>
+          <CuotasDashboardTab
+            filters={cuotaFilters}
+            onLoadingChange={handleCuotasLoadingChange}
+            onError={handleCuotasError}
+            onMetricsChange={handleCuotasMetricsChange}
+            onSummaryChange={handleCuotasSummaryChange}
+          />
         </TabsContent>
       </Tabs>
 


### PR DESCRIPTION
## Summary
- add a dedicated CuotasDashboardTab component that fetches the cuotas dashboard endpoint and renders the summary cards and cuotas table with pagination, loading, and error handling
- integrate the new cuotas tab into the financial reports view, wiring callbacks to update existing summary metrics without relying on the previous inline implementation

## Testing
- pnpm lint *(fails: existing project lint configuration expects React to be in scope and reports many legacy issues)*

------
https://chatgpt.com/codex/tasks/task_e_68f9b7dfda848328990b07943d1860b4